### PR TITLE
Newsletters feature for Ghost 5.0

### DIFF
--- a/app/creates/create_member.js
+++ b/app/creates/create_member.js
@@ -17,6 +17,10 @@ const createMember = async (z, bundle) => {
         expectedVersion = '>=4.46.0';
         action = 'member newsletters';
         memberData.newsletters = bundle.inputData.newsletters.map(id => ({id}));
+
+        if (bundle.inputData.newsletters.length === 0) {
+            memberData.subscribed = false;
+        }
     }
 
     // Member Labels was added in Ghost 3.6
@@ -72,13 +76,13 @@ module.exports = {
             {
                 key: 'subscription_option',
                 label: 'Subscription type',
-                helpText: 'Multiple newsletters for v5+, or a simple "subscribed" option for previous versions',
+                helpText: 'Multiple newsletters for Ghost v5+, or a subscribed option for previous versions',
                 required: true,
                 choices: {
-                    subscribed: 'Subscriptions',
-                    newsletters: 'Newsletters (v5+)'
+                    newsletters: 'Newsletters',
+                    subscribed: 'Legacy Subscription'
                 },
-                default: 'subscribed',
+                default: 'newsletters',
                 altersDynamicFields: true
             },
             function (z, bundle) {
@@ -90,6 +94,21 @@ module.exports = {
                         helpText: 'If false, member will be unsubscribed from all newsletters',
                         required: false
                     }];
+                } else {
+                    return [{
+                        key: 'newsletters_default',
+                        label: 'Subscribed to default newsletters',
+                        type: 'boolean',
+                        helpText: 'Newsletters with the "subscribe on signup" flag will be subscribed to by default',
+                        required: true,
+                        default: 'true',
+                        altersDynamicFields: true
+                    }];
+                }
+            },
+            function (z, bundle) {
+                if (bundle.inputData.subscription_option === 'subscribed' || bundle.inputData.newsletters_default === true) {
+                    return [];
                 } else {
                     return [{
                         key: 'newsletters',

--- a/app/creates/create_member.js
+++ b/app/creates/create_member.js
@@ -13,12 +13,13 @@ const createMember = async (z, bundle) => {
 
     if ('subscribed' in bundle.inputData) {
         memberData.subscribed = bundle.inputData.subscribed;
-    } else if ('newsletters' in bundle.inputData) {
+    } else if ('newsletters' in bundle.inputData && !('newsletters_default' in bundle.inputData && bundle.inputData.newsletters_default === true)) {
         expectedVersion = '>=4.46.0';
         action = 'member newsletters';
         memberData.newsletters = bundle.inputData.newsletters.map(id => ({id}));
 
         if (bundle.inputData.newsletters.length === 0) {
+            // Explicitly overriding newsletters and not including any, should mean unsubscribing the member
             memberData.subscribed = false;
         }
     }
@@ -101,7 +102,7 @@ module.exports = {
                         type: 'boolean',
                         helpText: 'Newsletters with the "subscribe on signup" flag will be subscribed to by default',
                         required: true,
-                        default: 'true',
+                        default: true,
                         altersDynamicFields: true
                     }];
                 }

--- a/app/creates/create_member.js
+++ b/app/creates/create_member.js
@@ -86,7 +86,8 @@ module.exports = {
                     single: 'Single newsletter',
                     multiple: 'Multiple newsletters'
                 },
-                default: 'newsletters',
+                helpText: 'How many newsletters does your site have? Multiple option for >= Ghost 5.0 only.',
+                default: 'single',
                 altersDynamicFields: true
             },
             function (z, bundle) {
@@ -98,16 +99,19 @@ module.exports = {
                         helpText: 'If false, member will not be subscribed to emails.',
                         required: false
                     }];
-                } else {
+                } else if (bundle.inputData.newsletter_count === 'multiple') {
                     return [{
                         key: 'newsletters_default',
                         label: 'Subscribe to default newsletters',
                         type: 'boolean',
-                        helpText: 'If false, you can subscribe to specific newsletters.',
+                        helpText: 'If false, you can subscribe member to specific newsletters or unsubscribe from all.',
                         required: true,
                         default: true,
                         altersDynamicFields: true
                     }];
+                } else {
+                    // Should never happen, but occasionally will be the case on load
+                    return [];
                 }
             },
             function (z, bundle) {

--- a/app/creates/create_member.js
+++ b/app/creates/create_member.js
@@ -17,7 +17,7 @@ const createMember = async (z, bundle) => {
     } else if (countSpecified && bundle.inputData.newsletter_count === 'multiple') {
         // Default newsletters is definitely set to false (using !(value !== false) because booleans are sometimes stringified before being set)
         if (!('newsletters_default' in bundle.inputData && bundle.inputData.newsletters_default !== false)) {
-            expectedVersion = '>=4.46.0';
+            expectedVersion = '>=5.0.0';
             action = 'member newsletters';
             memberData.newsletters = 'newsletters' in bundle.inputData
                 ? bundle.inputData.newsletters.map(id => ({id}))

--- a/app/creates/update_member.js
+++ b/app/creates/update_member.js
@@ -18,7 +18,7 @@ const updateMember = async (z, bundle) => {
     } else if (countSpecified && bundle.inputData.newsletter_count === 'multiple') {
         // Default newsletters is definitely set to false (using !(value !== false) because booleans are sometimes stringified before being set)
         if (!('newsletters_keepsame' in bundle.inputData && bundle.inputData.newsletters_keepsame !== false)) {
-            expectedVersion = '>=4.46.0';
+            expectedVersion = '>=5.0.0';
             action = 'member newsletters';
             memberData.newsletters = 'newsletters' in bundle.inputData
                 ? bundle.inputData.newsletters.map(id => ({id}))

--- a/app/creates/update_member.js
+++ b/app/creates/update_member.js
@@ -12,17 +12,21 @@ const updateMember = async (z, bundle) => {
         note: bundle.inputData.note
     };
 
-    if ('subscribed' in bundle.inputData) {
+    const countSpecified = 'newsletter_count' in bundle.inputData;
+    if (countSpecified && bundle.inputData.newsletter_count === 'single') {
         memberData.subscribed = bundle.inputData.subscribed;
-    } else if ('newsletters' in bundle.inputData && !('newsletters_keepsame' in bundle.inputData && bundle.inputData.newsletters_keepsame === true)) {
-        expectedVersion = '>=4.46.0';
-        action = 'member newsletters';
-        memberData.newsletters = bundle.inputData.newsletters.map(id => ({id}));
-
-        if (bundle.inputData.newsletters.length === 0) {
-            // Explicitly overriding newsletters and not including any, should mean unsubscribing the member
-            memberData.subscribed = false;
+    } else if (countSpecified && bundle.inputData.newsletter_count === 'multiple') {
+        // Default newsletters is definitely set to false (using !(value !== false) because booleans are sometimes stringified before being set)
+        if (!('newsletters_keepsame' in bundle.inputData && bundle.inputData.newsletters_keepsame !== false)) {
+            expectedVersion = '>=4.46.0';
+            action = 'member newsletters';
+            memberData.newsletters = 'newsletters' in bundle.inputData
+                ? bundle.inputData.newsletters.map(id => ({id}))
+                : [];
         }
+    } else {
+        // Assume single newsletter for older Zaps
+        memberData.subscribed = bundle.inputData.subscribed;
     }
 
     // Member Labels was added in Ghost 3.6
@@ -71,24 +75,23 @@ module.exports = {
             {key: 'email', required: false},
             {key: 'note', required: false},
             {
-                key: 'subscription_option',
-                label: 'Subscription type',
-                helpText: 'Multiple newsletters for Ghost v5+, or a subscribed option for previous versions',
+                key: 'newsletter_count',
+                label: 'Number of newsletters',
                 required: true,
                 choices: {
-                    newsletters: 'Newsletters',
-                    subscribed: 'Legacy Subscription'
+                    single: 'Single newsletter',
+                    multiple: 'Multiple newsletters'
                 },
                 default: 'newsletters',
                 altersDynamicFields: true
             },
             function (z, bundle) {
-                if (bundle.inputData.subscription_option === 'subscribed') {
+                if (bundle.inputData.newsletter_count === 'single') {
                     return [{
                         key: 'subscribed',
                         label: 'Subscribed to newsletter',
                         type: 'boolean',
-                        helpText: 'If false, member will be unsubscribed from all newsletters',
+                        helpText: 'If false, member will not be subscribed to emails.',
                         required: false
                     }];
                 } else {
@@ -103,13 +106,14 @@ module.exports = {
                 }
             },
             function (z, bundle) {
-                if (bundle.inputData.subscription_option === 'subscribed' || bundle.inputData.newsletters_keepsame === true) {
+                // Using value !== false because booleans in Zapier are occasionally strings
+                if (bundle.inputData.newsletter_count === 'single' || bundle.inputData.newsletters_keepsame !== false) {
                     return [];
                 } else {
                     return [{
                         key: 'newsletters',
                         label: 'Newsletter subscriptions',
-                        helpText: 'Choose which newsletters the member will be subscribed to',
+                        helpText: 'Subscribe member to specific newsletters. Leave blank to unsubscribe from all.',
                         required: false,
                         list: true,
                         dynamic: 'newsletter_created.id.name'

--- a/app/creates/update_member.js
+++ b/app/creates/update_member.js
@@ -82,7 +82,8 @@ module.exports = {
                     single: 'Single newsletter',
                     multiple: 'Multiple newsletters'
                 },
-                default: 'newsletters',
+                helpText: 'How many newsletters does your site have? Multiple option for >= Ghost 5.0 only.',
+                default: 'single',
                 altersDynamicFields: true
             },
             function (z, bundle) {
@@ -94,7 +95,7 @@ module.exports = {
                         helpText: 'If false, member will not be subscribed to emails.',
                         required: false
                     }];
-                } else {
+                } else if (bundle.inputData.newsletter_count === 'multiple') {
                     return [{
                         key: 'newsletters_keepsame',
                         label: 'Keep the current set of newsletters for the member',
@@ -103,6 +104,8 @@ module.exports = {
                         default: true,
                         altersDynamicFields: true
                     }];
+                } else {
+                    return [];
                 }
             },
             function (z, bundle) {

--- a/app/triggers/index.js
+++ b/app/triggers/index.js
@@ -8,5 +8,6 @@ module.exports = {
     post_scheduled: require('./post_scheduled'),
     subscriber_created: require('./subscriber_created'),
     subscriber_deleted: require('./subscriber_deleted'),
-    tag_created: require('./tag_created')
+    tag_created: require('./tag_created'),
+    newsletter_created: require('./newsletter_created')
 };

--- a/app/triggers/newsletter_created.js
+++ b/app/triggers/newsletter_created.js
@@ -2,8 +2,8 @@ const _ = require('lodash');
 const {initAdminApi} = require('../lib/utils');
 const webhooks = require('../lib/webhooks');
 
-const subscribeWebhook = _.partial(webhooks.newsletter, 'newsletter.added');
-const unsubscribeWebhook = webhooks.newsletter;
+const subscribeWebhook = _.partial(webhooks.subscribe, 'newsletter.added');
+const unsubscribeWebhook = webhooks.unsubscribe;
 
 // triggers on user.added. Formats the API response ready for passing to
 // the zap which expects an array
@@ -19,13 +19,13 @@ const listNewsletters = (z, {authData, meta}) => {
     const api = initAdminApi(z, authData);
 
     if (meta.isFillingDynamicDropdown) {
-        return api.newsletter.browse({
+        return api.newsletters.browse({
             order: 'name DESC',
             limit: 'all'
         });
     }
 
-    return api.newsletter.browse({
+    return api.newsletters.browse({
         order: 'created_at DESC',
         limit: 1
     });

--- a/app/triggers/newsletter_created.js
+++ b/app/triggers/newsletter_created.js
@@ -1,0 +1,82 @@
+const _ = require('lodash');
+const {initAdminApi} = require('../lib/utils');
+const webhooks = require('../lib/webhooks');
+
+const subscribeWebhook = _.partial(webhooks.newsletter, 'newsletter.added');
+const unsubscribeWebhook = webhooks.newsletter;
+
+// triggers on user.added. Formats the API response ready for passing to
+// the zap which expects an array
+const handleWebhook = (z, bundle) => {
+    // bundle.cleanedRequest will include the parsed JSON object (if it's not a
+    // test poll) and also a .querystring property with the URL's query string.
+    const {user} = bundle.cleanedRequest;
+
+    return [user.current];
+};
+
+const listNewsletters = (z, {authData, meta}) => {
+    const api = initAdminApi(z, authData);
+
+    if (meta.isFillingDynamicDropdown) {
+        return api.newsletter.browse({
+            order: 'name DESC',
+            limit: 'all'
+        });
+    }
+
+    return api.newsletter.browse({
+        order: 'created_at DESC',
+        limit: 1
+    });
+};
+
+module.exports = {
+    key: 'newsletter_created',
+    noun: 'Newsletter',
+
+    display: {
+        label: 'Newsletter Created',
+        description: 'Triggers when a new newsletter is added.',
+        hidden: true // only used by newsletter dynamic dropdown
+    },
+
+    operation: {
+        inputFields: [],
+
+        type: 'hook',
+
+        performSubscribe: subscribeWebhook,
+        performUnsubscribe: unsubscribeWebhook,
+
+        perform: handleWebhook,
+        performList: listNewsletters,
+
+        sample: {
+            id: '627be9e49278a3c9b09f8883',
+            name: 'Default newsletter',
+            description: 'Thoughts, stories and ideas.',
+            slug: 'default-newsletter',
+            sender_email: null,
+            sender_reply_to: 'newsletter',
+            status: 'active',
+            visibility: 'members',
+            subscribe_on_signup: true,
+            sort_order: 0,
+            header_image: null,
+            show_header_icon: true,
+            show_header_title: true,
+            title_font_category: 'sans_serif',
+            title_alignment: 'center',
+            show_feature_image: true,
+            body_font_category: 'sans_serif',
+            footer_content: '',
+            show_badge: true,
+            sender_name: null,
+            created_at: '2022-05-11T16:52:52.000Z',
+            updated_at: null,
+            show_header_name: false,
+            uuid: 'c9e80472-8017-4abc-8bb0-6393f1b39596'
+        }
+    }
+};

--- a/app/triggers/newsletter_created.js
+++ b/app/triggers/newsletter_created.js
@@ -1,21 +1,36 @@
-const _ = require('lodash');
-const {initAdminApi} = require('../lib/utils');
+const {initAdminApi, versionCheck} = require('../lib/utils');
 const webhooks = require('../lib/webhooks');
 
-const subscribeWebhook = _.partial(webhooks.subscribe, 'newsletter.added');
-const unsubscribeWebhook = webhooks.unsubscribe;
+const subscribeWebhook = async (z, bundle) => {
+    // Newsletters was added in Ghost 5.0
+    await versionCheck('>=5.0.0', 'newsletters', z, bundle);
 
-// triggers on user.added. Formats the API response ready for passing to
+    return webhooks.subscribe('newsletter.added', z, bundle);
+};
+
+const unsubscribeWebhook = async (z, bundle) => {
+    // Newsletters was added in Ghost 5.0
+    await versionCheck('>=5.0.0', 'newsletters', z, bundle);
+
+    return webhooks.unsubscribe(z, bundle);
+};
+
+// triggers on newsletter.added. Formats the API response ready for passing to
 // the zap which expects an array
 const handleWebhook = (z, bundle) => {
     // bundle.cleanedRequest will include the parsed JSON object (if it's not a
     // test poll) and also a .querystring property with the URL's query string.
-    const {user} = bundle.cleanedRequest;
+    const {newsletter} = bundle.cleanedRequest;
 
-    return [user.current];
+    return [newsletter.current];
 };
 
-const listNewsletters = (z, {authData, meta}) => {
+const listNewsletters = async (z, bundle) => {
+    // Newsletters was added in Ghost 5.0
+    await versionCheck('>=5.0.0', 'newsletters', z, bundle);
+
+    const {authData, meta} = bundle;
+
     const api = initAdminApi(z, authData);
 
     if (meta.isFillingDynamicDropdown) {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "npm": ">=5.6.0"
   },
   "dependencies": {
-    "@tryghost/admin-api": "1.11.0",
+    "@tryghost/admin-api": "1.12.0",
     "semver": "6.3.0",
     "zapier-platform-core": "11.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ghost-zapier",
-  "version": "2.5.2",
+  "version": "2.6.0",
   "description": "Ghost integration for the Zapier platform.",
   "repository": "TryGhost/Zapier",
   "homepage": "https://ghost.org/",

--- a/test/triggers/newsletter_created.test.js
+++ b/test/triggers/newsletter_created.test.js
@@ -1,0 +1,177 @@
+require('should');
+const nock = require('nock');
+
+const zapier = require('zapier-platform-core');
+
+// Use this to make test calls into your app:
+const App = require('../../index');
+const appTester = zapier.createAppTester(App);
+
+describe('Triggers', function () {
+    describe('Newsletter Created', function () {
+        let apiMock, authData;
+
+        beforeEach(function () {
+            apiMock = nock('http://zapier-test.ghost.io', {
+                reqheaders: {
+                    'User-Agent': new RegExp(`Zapier/${App.version} GhostAdminSDK/\\d+.\\d+.\\d+`)
+                }
+            });
+            authData = {
+                adminApiUrl: 'http://zapier-test.ghost.io',
+                adminApiKey: '5c3e1182e79eace7f58c9c3b:7202e874ccae6f1ee6688bb700f356b672fb078d8465860852652037f7c7459ddbd2f2a6e9aa05a40b499ae20027d9f9ba2e5004aa9ab6510b90a5dac674cbc1'
+            };
+        });
+
+        afterEach(function () {
+            nock.cleanAll();
+        });
+
+        describe('with supported version', function () {
+            beforeEach(function () {
+                apiMock.get('/ghost/api/v2/admin/site/').reply(200, {
+                    site: {version: '5.0'}
+                });
+            });
+
+            it('loads newsletter from webhook data', function () {
+                let bundle = Object.assign({}, {authData}, {
+                    inputData: {},
+                    cleanedRequest: {
+                        newsletter: {
+                            current: {
+                                id: '627be9e49278a3c9b09f8883',
+                                name: 'Default newsletter',
+                                description: 'Thoughts, stories and ideas.',
+                                slug: 'default-newsletter',
+                                created_at: '2019-03-22T08:39:02.890Z',
+                                updated_at: '2019-03-22T08:39:02.890Z'
+                            },
+                            previous: {}
+                        }
+                    }
+                });
+
+                return appTester(App.triggers.newsletter_created.operation.perform, bundle)
+                    .then(([newsletter]) => {
+                        newsletter.id.should.eql('627be9e49278a3c9b09f8883');
+                        newsletter.name.should.eql('Default newsletter');
+                        newsletter.slug.should.eql('default-newsletter');
+                    });
+            });
+
+            it('loads newsletter from list', function () {
+                let bundle = Object.assign({}, {authData}, {
+                    inputData: {},
+                    meta: {
+                        frontend: true
+                    }
+                });
+
+                apiMock.get('/ghost/api/v2/admin/newsletters/')
+                    .query({
+                        order: 'created_at DESC',
+                        limit: 1
+                    })
+                    .reply(200, {
+                        newsletters: [{
+                            id: '627be9e49278a3c9b09f8883',
+                            name: 'Default newsletter',
+                            description: 'Thoughts, stories and ideas.',
+                            slug: 'default-newsletter',
+                            created_at: '2019-03-22T08:39:02.890Z',
+                            updated_at: '2019-03-22T08:39:02.890Z'
+                        }],
+                        meta: {
+                            pagination: {
+                                page: 1,
+                                limit: 1,
+                                pages: 1,
+                                total: 1,
+                                next: null,
+                                prev: null
+                            }
+                        }
+                    });
+
+                return appTester(App.triggers.newsletter_created.operation.performList, bundle)
+                    .then((results) => {
+                        apiMock.isDone().should.be.true;
+                        results.length.should.eql(1);
+
+                        let [firstNewsletter] = results;
+                        firstNewsletter.id.should.eql('627be9e49278a3c9b09f8883');
+                        firstNewsletter.name.should.eql('Default newsletter');
+                        firstNewsletter.slug.should.eql('default-newsletter');
+                    });
+            });
+
+            it('subscribes to webhook', function () {
+                let bundle = Object.assign({}, {authData}, {
+                    targetUrl: 'https://webooks.zapier.com/ghost/newsletter'
+                });
+
+                apiMock.post('/ghost/api/v2/admin/webhooks/', {
+                    webhooks: [{
+                        integration_id: '5c3e1182e79eace7f58c9c3b',
+                        target_url: 'https://webooks.zapier.com/ghost/newsletter',
+                        event: 'newsletter.added'
+                    }]
+                }).reply(201, {
+                    webhooks: [{
+                        id: '12345',
+                        target_url: 'https://webooks.zapier.com/ghost/newsletter',
+                        event: 'newsletter.added'
+                    }]
+                });
+
+                return appTester(App.triggers.newsletter_created.operation.performSubscribe, bundle)
+                    .then(() => {
+                        apiMock.isDone().should.be.true;
+                    });
+            });
+
+            it('unsubscribes from webhook', function () {
+                let bundle = Object.assign({}, {authData}, {
+                    subscribeData: {
+                        id: '12345',
+                        target_url: 'https://webooks.zapier.com/ghost/member',
+                        event: 'newsletter.added'
+                    }
+                });
+
+                apiMock.delete('/ghost/api/v2/admin/webhooks/12345/')
+                    .reply(204);
+
+                return appTester(App.triggers.newsletter_created.operation.performUnsubscribe, bundle)
+                    .then(() => {
+                        apiMock.isDone().should.be.true;
+                    });
+            });
+        });
+
+        describe('with unsupported version', function () {
+            beforeEach(function () {
+                apiMock.get('/ghost/api/v2/admin/site/').reply(200, {
+                    site: {version: '4.46'}
+                });
+            });
+
+            it('shows unsupported error for list', function () {
+                let bundle = Object.assign({}, {authData}, {
+                    meta: {
+                        isFillingDynamicDropdown: true
+                    }
+                });
+
+                return appTester(App.triggers.newsletter_created.operation.performList, bundle)
+                    .then(() => {
+                        true.should.equal(false);
+                    }, (err) => {
+                        // err.name.should.equal('HaltedError');
+                        err.message.should.match(/does not support newsletters. Supported version range is >=5.0.0, you are using 4.46/);
+                    });
+            });
+        });
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,12 +23,12 @@
   resolved "https://registry.yarnpkg.com/@ember-data/rfc395-data/-/rfc395-data-0.0.4.tgz#ecb86efdf5d7733a76ff14ea651a1b0ed1f8a843"
   integrity sha512-tGRdvgC9/QMQSuSuJV45xoyhI0Pzjm7A9o/MVVA3HakXIImJbbzx/k/6dO9CUEQXIyS2y0fW6C1XaYOG7rY0FQ==
 
-"@tryghost/admin-api@1.11.0":
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/@tryghost/admin-api/-/admin-api-1.11.0.tgz#ac3d7f5ec8406a307fec4562f21aa256c4c7fb3e"
-  integrity sha512-LX2W3v2CdreGUseRIk94tOWdIr+oAejkrXTelpJwSpadHTD0/QcYMxlFKMDLjAcvH+h/+Z67Bce7zRsRZjDvRw==
+"@tryghost/admin-api@1.12.0":
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/@tryghost/admin-api/-/admin-api-1.12.0.tgz#911b82629b9e97b916eeea2dafb8d3c36057bb08"
+  integrity sha512-b/CDERWtPCLQJdwGhXyfOPuZQTqqbJj/Fct4OjT1eQSbP8G2a7w7pVug56NHL1WPv0x9L7UIbANJPnhFy1lzyg==
   dependencies:
-    axios "^0.21.1"
+    axios "^0.27.0"
     form-data "^4.0.0"
     jsonwebtoken "^8.4.0"
 
@@ -123,12 +123,13 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
 
-axios@^0.21.1:
-  version "0.21.4"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
-  integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
+axios@^0.27.0:
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.27.2.tgz#207658cc8621606e586c85db4b41a750e756d972"
+  integrity sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==
   dependencies:
-    follow-redirects "^1.14.0"
+    follow-redirects "^1.14.9"
+    form-data "^4.0.0"
 
 balanced-match@^1.0.0:
   version "1.0.0"
@@ -609,10 +610,10 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.1.tgz#69e57caa8f0eacbc281d2e2cb458d46fdb449e08"
   integrity sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==
 
-follow-redirects@^1.14.0:
-  version "1.14.9"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.9.tgz#dd4ea157de7bfaf9ea9b3fbd85aa16951f78d8d7"
-  integrity sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==
+follow-redirects@^1.14.9:
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.0.tgz#06441868281c86d0dda4ad8bdaead2d02dca89d4"
+  integrity sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ==
 
 form-data@4.0.0, form-data@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Added the newsletter feature for Ghost 5.0.

In the form, a new dropdown allows the user to select either single or multiple newsletter mode. Single newsletter mode uses the original "subscribed" boolean, and multiple newsletter mode includes a dropdown to select the newsletters.