### PR TITLE
Add Node 20, 22, 24 to CI test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && !startsWith(github.head_ref, 'renovate/'))
     strategy:
       matrix:
-        node: [ '14' ]
+        node: [ '14', '20', '22', '24' ]
     name: Node ${{ matrix.node }}
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Adds Node 20, 22, and 24 to the existing test matrix alongside Node 14.

Note: the workflow also uses `ubuntu-18.04` which is deprecated — may need updating separately.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change that increases test coverage across Node versions; no runtime or production code is modified.
> 
> **Overview**
> Expands the GitHub Actions CI `test.yml` Node.js matrix to run the existing install/lint/test workflow on **Node 14, 20, 22, and 24** instead of only Node 14.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 432c195ed2a3222d62bb1332a79c54b16219c56c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->