### PR TITLE
Update CI runner from ubuntu-18.04 to ubuntu-latest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
       - 'renovate/*'
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && !startsWith(github.head_ref, 'renovate/'))
     strategy:
       matrix:


### PR DESCRIPTION
ubuntu-18.04 runners were removed from GitHub Actions in April 2023. Updates to `ubuntu-latest` (currently 24.04).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change that updates the GitHub Actions runner image; low risk aside from potential environment-dependent test/tooling differences on the newer Ubuntu version.
> 
> **Overview**
> Updates the GitHub Actions `Test` workflow to run on `ubuntu-latest` instead of the deprecated `ubuntu-18.04` runner.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit da807a9a64413cf2a49d4b005ab023e21b09add0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->