### PR TITLE
Fix CI: drop unpinned zapier-platform-cli, pin actions, add timeouts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,16 +9,18 @@ jobs:
   build:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && !startsWith(github.head_ref, 'renovate/'))
+    timeout-minutes: 10
     strategy:
+      fail-fast: false
       matrix:
         node: [ '14', '20', '22', '24' ]
     name: Node ${{ matrix.node }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
+          cache: yarn
       - run: yarn
-      - run: npm install -g zapier-platform-cli
       - run: yarn lint
-      - run: zapier test
+      - run: yarn test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,8 +16,8 @@ jobs:
         node: [ '14', '20', '22', '24' ]
     name: Node ${{ matrix.node }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ matrix.node }}
           cache: yarn


### PR DESCRIPTION
## Why

Main CI is red. The last `Test` run on main ([run 21837181082](https://github.com/TryGhost/Zapier/actions/runs/21837181082), commit ed99b62) failed at the `Run zapier test` step on the Node 20 leg, and the two runs before it ([21837069198](https://github.com/TryGhost/Zapier/actions/runs/21837069198), [21211094890](https://github.com/TryGhost/Zapier/actions/runs/21211094890)) hung for 24 hours before being cancelled.

Root cause: the workflow ran `npm install -g zapier-platform-cli` unpinned, so every run installed the latest release. CLI v19 declares `engines.node >=18.20` (breaking the Node 14 leg) and renamed the `zapier` binary to `zapier-platform`; older CLI versions prompt for input on TTY-less runners, which is what caused the 24h hangs. The CLI adds nothing to CI anyway — `zapier test` just runs `zapier validate` and then spawns `yarn run --silent test` (verified in the CLI source), and the mocha suite needs nothing from the CLI.

## What changed

Minimal workflow-only change to `.github/workflows/test.yml` — no package.json or test changes:

- Drop the `npm install -g zapier-platform-cli` step and run `yarn test` directly instead of `zapier test`
- Update `actions/checkout` to v4.3.1 and `actions/setup-node` to v4.4.0 with `cache: yarn`, pinned to full-length commit SHAs as required by TryGhost org policy (runner-side actions, independent of the matrix Node version — the Node 14 leg keeps working)
- `timeout-minutes: 10` on the job so a hung job can never burn 24 hours again
- `fail-fast: false` so one failing leg still reports the others

Triggers, the renovate `if:` condition, the [14, 20, 22, 24] matrix, and the `yarn` / `yarn lint` steps are unchanged.

## Local verification

- `yarn lint` — passes (eslint, clean)
- `yarn test` — passes, 98 passing (1s)

## CI

All four matrix legs green: Node 14 (21s), Node 20 (18s), Node 22 (15s), Node 24 (15s).

ref [GVA-831](https://linear.app/ghost/issue/GVA-831/clean-repos-zapier)