### PR TITLE
Add missing unit tests and enforce 80% coverage

### DIFF
--- a/.c8rc.json
+++ b/.c8rc.json
@@ -1,0 +1,10 @@
+{
+    "all": true,
+    "include": ["app/**/*.js", "index.js"],
+    "reporter": ["text", "lcov"],
+    "check-coverage": true,
+    "lines": 80,
+    "statements": 80,
+    "branches": 80,
+    "functions": 80
+}

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 .environment
 .env
 .eslintcache
+coverage

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "main": "index.js",
   "scripts": {
     "lint": "eslint . --ext .js --cache",
-    "test": "mocha --recursive"
+    "test": "c8 mocha --recursive"
   },
   "engines": {
     "node": ">=14.x",
@@ -21,6 +21,7 @@
     "zapier-platform-core": "12.0.3"
   },
   "devDependencies": {
+    "c8": "^7.14.0",
     "eslint": "8.16.0",
     "eslint-plugin-ghost": "2.14.0",
     "mocha": "10.0.0",

--- a/test/creates/create_member.test.js
+++ b/test/creates/create_member.test.js
@@ -403,6 +403,42 @@ describe('Creates', function () {
                     });
             });
 
+            it('creates a member unsubscribed from all newsletters when none are selected', function () {
+                let bundle = Object.assign({}, {authData}, {
+                    inputData: {
+                        name: 'Test Member',
+                        email: 'test@example.com',
+                        newsletter_count: 'multiple',
+                        newsletters_default: false
+                    }
+                });
+
+                apiMock.post('/ghost/api/v3/admin/members/?send_email=true', {
+                    members: [{
+                        name: 'Test Member',
+                        email: 'test@example.com',
+                        newsletters: []
+                    }]
+                }).reply(201, {
+                    members: [{
+                        id: '5c9c9c8d51b5bf974afad2a4',
+                        name: 'Test Member',
+                        email: 'test@example.com',
+                        created_at: '2019-10-03T11:54:10.123Z',
+                        updated_at: '2019-10-03T11:54:10.123Z',
+                        newsletters: []
+                    }]
+                });
+
+                return appTester(App.creates.create_member.operation.perform, bundle)
+                    .then((member) => {
+                        apiMock.isDone().should.be.true;
+
+                        member.id.should.equal('5c9c9c8d51b5bf974afad2a4');
+                        member.newsletters.length.should.equal(0);
+                    });
+            });
+
             it('creates a member subscribed ignoring unused input data', function () {
                 let bundle = Object.assign({}, {authData}, {
                     inputData: {

--- a/test/creates/create_member.test.js
+++ b/test/creates/create_member.test.js
@@ -140,6 +140,42 @@ describe('Creates', function () {
                     });
             });
 
+            it('creates a member subscribed to a single newsletter', function () {
+                let bundle = Object.assign({}, {authData}, {
+                    inputData: {
+                        name: 'Test Member',
+                        email: 'test@example.com',
+                        newsletter_count: 'single',
+                        subscribed: true
+                    }
+                });
+
+                apiMock.post('/ghost/api/v3/admin/members/?send_email=true', {
+                    members: [{
+                        name: 'Test Member',
+                        email: 'test@example.com',
+                        subscribed: true
+                    }]
+                }).reply(201, {
+                    members: [{
+                        id: '5c9c9c8d51b5bf974afad2a4',
+                        name: 'Test Member',
+                        email: 'test@example.com',
+                        subscribed: true,
+                        created_at: '2019-10-03T11:54:10.123Z',
+                        updated_at: '2019-10-03T11:54:10.123Z'
+                    }]
+                });
+
+                return appTester(App.creates.create_member.operation.perform, bundle)
+                    .then((member) => {
+                        apiMock.isDone().should.be.true;
+
+                        member.id.should.equal('5c9c9c8d51b5bf974afad2a4');
+                        member.subscribed.should.equal(true);
+                    });
+            });
+
             it('has a friendly, halting validation error', function () {
                 let bundle = Object.assign({}, {authData}, {
                     inputData: {
@@ -414,6 +450,79 @@ describe('Creates', function () {
                         member.email.should.equal('test@example.com');
                         member.subscribed.should.equal(true);
                         member.newsletters.length.should.equal(2);
+                    });
+            });
+        });
+
+        describe('dynamic input fields', function () {
+            // indexes of the dynamic field functions within operation.inputFields
+            const SUBSCRIPTION_FIELD = 4;
+            const NEWSLETTERS_FIELD = 5;
+
+            it('shows the subscribed field for a single newsletter', function () {
+                let bundle = Object.assign({}, {authData}, {
+                    inputData: {
+                        newsletter_count: 'single'
+                    }
+                });
+
+                return appTester(App.creates.create_member.operation.inputFields[SUBSCRIPTION_FIELD], bundle)
+                    .then(([field]) => {
+                        field.key.should.eql('subscribed');
+                        field.type.should.eql('boolean');
+                    });
+            });
+
+            it('shows the default newsletters field for multiple newsletters', function () {
+                let bundle = Object.assign({}, {authData}, {
+                    inputData: {
+                        newsletter_count: 'multiple'
+                    }
+                });
+
+                return appTester(App.creates.create_member.operation.inputFields[SUBSCRIPTION_FIELD], bundle)
+                    .then(([field]) => {
+                        field.key.should.eql('newsletters_default');
+                        field.required.should.eql(true);
+                    });
+            });
+
+            it('shows no subscription field before a newsletter count is chosen', function () {
+                let bundle = Object.assign({}, {authData}, {
+                    inputData: {}
+                });
+
+                return appTester(App.creates.create_member.operation.inputFields[SUBSCRIPTION_FIELD], bundle)
+                    .then((fields) => {
+                        fields.length.should.eql(0);
+                    });
+            });
+
+            it('shows the newsletters field when default newsletters are disabled', function () {
+                let bundle = Object.assign({}, {authData}, {
+                    inputData: {
+                        newsletter_count: 'multiple',
+                        newsletters_default: false
+                    }
+                });
+
+                return appTester(App.creates.create_member.operation.inputFields[NEWSLETTERS_FIELD], bundle)
+                    .then(([field]) => {
+                        field.key.should.eql('newsletters');
+                        field.list.should.eql(true);
+                    });
+            });
+
+            it('hides the newsletters field for a single newsletter', function () {
+                let bundle = Object.assign({}, {authData}, {
+                    inputData: {
+                        newsletter_count: 'single'
+                    }
+                });
+
+                return appTester(App.creates.create_member.operation.inputFields[NEWSLETTERS_FIELD], bundle)
+                    .then((fields) => {
+                        fields.length.should.eql(0);
                     });
             });
         });

--- a/test/creates/create_post.test.js
+++ b/test/creates/create_post.test.js
@@ -1,0 +1,170 @@
+require('should');
+const nock = require('nock');
+
+const zapier = require('zapier-platform-core');
+
+// Use this to make test calls into your app:
+const App = require('../../index');
+const appTester = zapier.createAppTester(App);
+
+// indexes of the dynamic field functions within operation.inputFields
+const PUBLISHED_AT_FIELD = 3;
+const CONTENT_FIELD = 5;
+
+describe('Creates', function () {
+    describe('Create Post', function () {
+        let apiMock, authData;
+
+        beforeEach(function () {
+            apiMock = nock('http://zapier-test.ghost.io', {
+                reqheaders: {
+                    'User-Agent': new RegExp(`Zapier/${App.version} GhostAdminSDK/\\d+.\\d+.\\d+`)
+                }
+            });
+            authData = {
+                adminApiUrl: 'http://zapier-test.ghost.io',
+                adminApiKey: '5c3e1182e79eace7f58c9c3b:7202e874ccae6f1ee6688bb700f356b672fb078d8465860852652037f7c7459ddbd2f2a6e9aa05a40b499ae20027d9f9ba2e5004aa9ab6510b90a5dac674cbc1'
+            };
+        });
+
+        afterEach(function () {
+            nock.cleanAll();
+        });
+
+        it('creates a post from html, mapping tag and author slugs', function () {
+            let bundle = Object.assign({}, {authData}, {
+                inputData: {
+                    title: 'Test Post',
+                    status: 'draft',
+                    content_format: 'html',
+                    html: '<p>Test content</p>',
+                    mobiledoc: '{"version":"0.3.1"}',
+                    tags: ['getting-started'],
+                    authors: ['ghost']
+                }
+            });
+
+            // html input is converted server-side, so the `source=html` query
+            // param must be present and the unused mobiledoc content dropped
+            apiMock.post('/ghost/api/v2/admin/posts/?source=html', {
+                posts: [{
+                    title: 'Test Post',
+                    status: 'draft',
+                    html: '<p>Test content</p>',
+                    tags: [{slug: 'getting-started'}],
+                    authors: [{slug: 'ghost'}]
+                }]
+            }).reply(201, {
+                posts: [{
+                    id: '5c34ce2370401002b874c585',
+                    title: 'Test Post',
+                    slug: 'test-post',
+                    status: 'draft'
+                }]
+            });
+
+            return appTester(App.creates.create_post.operation.perform, bundle)
+                .then((post) => {
+                    apiMock.isDone().should.be.true;
+
+                    post.id.should.eql('5c34ce2370401002b874c585');
+                    post.title.should.eql('Test Post');
+                    post.slug.should.eql('test-post');
+                });
+        });
+
+        it('creates a post from mobiledoc, dropping unused html content', function () {
+            let bundle = Object.assign({}, {authData}, {
+                inputData: {
+                    title: 'Test Post',
+                    status: 'published',
+                    content_format: 'mobiledoc',
+                    mobiledoc: '{"version":"0.3.1"}',
+                    html: '<p>Test content</p>'
+                }
+            });
+
+            apiMock.post('/ghost/api/v2/admin/posts/', {
+                posts: [{
+                    title: 'Test Post',
+                    status: 'published',
+                    mobiledoc: '{"version":"0.3.1"}',
+                    tags: [],
+                    authors: []
+                }]
+            }).reply(201, {
+                posts: [{
+                    id: '5c34ce2370401002b874c585',
+                    title: 'Test Post',
+                    slug: 'test-post',
+                    status: 'published'
+                }]
+            });
+
+            return appTester(App.creates.create_post.operation.perform, bundle)
+                .then((post) => {
+                    apiMock.isDone().should.be.true;
+
+                    post.id.should.eql('5c34ce2370401002b874c585');
+                    post.status.should.eql('published');
+                });
+        });
+
+        it('requires published_at when the post is scheduled', function () {
+            let bundle = Object.assign({}, {authData}, {
+                inputData: {
+                    status: 'scheduled'
+                }
+            });
+
+            return appTester(App.creates.create_post.operation.inputFields[PUBLISHED_AT_FIELD], bundle)
+                .then(([field]) => {
+                    field.key.should.eql('published_at');
+                    field.required.should.eql(true);
+                    field.type.should.eql('datetime');
+                });
+        });
+
+        it('does not require published_at for other statuses', function () {
+            let bundle = Object.assign({}, {authData}, {
+                inputData: {
+                    status: 'draft'
+                }
+            });
+
+            return appTester(App.creates.create_post.operation.inputFields[PUBLISHED_AT_FIELD], bundle)
+                .then(([field]) => {
+                    field.key.should.eql('published_at');
+                    field.required.should.eql(false);
+                });
+        });
+
+        it('shows the html content field for html format', function () {
+            let bundle = Object.assign({}, {authData}, {
+                inputData: {
+                    content_format: 'html'
+                }
+            });
+
+            return appTester(App.creates.create_post.operation.inputFields[CONTENT_FIELD], bundle)
+                .then(([field]) => {
+                    field.key.should.eql('html');
+                    field.type.should.eql('text');
+                });
+        });
+
+        it('shows the mobiledoc content field for mobiledoc format', function () {
+            let bundle = Object.assign({}, {authData}, {
+                inputData: {
+                    content_format: 'mobiledoc'
+                }
+            });
+
+            return appTester(App.creates.create_post.operation.inputFields[CONTENT_FIELD], bundle)
+                .then(([field]) => {
+                    field.key.should.eql('mobiledoc');
+                    field.type.should.eql('text');
+                });
+        });
+    });
+});

--- a/test/creates/update_member.test.js
+++ b/test/creates/update_member.test.js
@@ -70,6 +70,41 @@ describe('Creates', function () {
                     });
             });
 
+            it('updates a member subscribed to a single newsletter', function () {
+                let bundle = Object.assign({}, {authData}, {
+                    inputData: {
+                        id: '5c9c9c8d51b5bf974afad2a4',
+                        name: 'Test Member',
+                        newsletter_count: 'single',
+                        subscribed: true
+                    }
+                });
+
+                apiMock.put('/ghost/api/v3/admin/members/5c9c9c8d51b5bf974afad2a4/', {
+                    members: [{
+                        name: 'Test Member',
+                        subscribed: true
+                    }]
+                }).reply(200, {
+                    members: [{
+                        id: '5c9c9c8d51b5bf974afad2a4',
+                        name: 'Test Member',
+                        email: 'test@example.com',
+                        subscribed: true,
+                        created_at: '2019-10-03T11:54:10.123Z',
+                        updated_at: '2019-10-03T11:54:10.123Z'
+                    }]
+                });
+
+                return appTester(App.creates.update_member.operation.perform, bundle)
+                    .then((member) => {
+                        apiMock.isDone().should.be.true;
+
+                        member.id.should.equal('5c9c9c8d51b5bf974afad2a4');
+                        member.subscribed.should.equal(true);
+                    });
+            });
+
             it('has a friendly, halting validation error', function () {
                 let bundle = Object.assign({}, {authData}, {
                     inputData: {
@@ -232,6 +267,225 @@ describe('Creates', function () {
                         member.name.should.equal('Test Member');
                         member.email.should.equal('test@example.com');
                         member.comped.should.equal(true);
+                    });
+            });
+        });
+
+        describe('with supported version >= 5.0.0', function () {
+            beforeEach(function () {
+                apiMock.get('/ghost/api/v2/admin/site/').reply(200, {
+                    site: {version: '5.0'}
+                });
+            });
+
+            it('updates a member subscribed to multiple newsletters', function () {
+                let bundle = Object.assign({}, {authData}, {
+                    inputData: {
+                        id: '5c9c9c8d51b5bf974afad2a4',
+                        name: 'Test Member',
+                        newsletter_count: 'multiple',
+                        newsletters_keepsame: false,
+                        newsletters: ['one', 'two']
+                    }
+                });
+
+                apiMock.put('/ghost/api/v3/admin/members/5c9c9c8d51b5bf974afad2a4/', {
+                    members: [{
+                        name: 'Test Member',
+                        newsletters: [{
+                            id: 'one'
+                        }, {
+                            id: 'two'
+                        }]
+                    }]
+                }).reply(200, {
+                    members: [{
+                        id: '5c9c9c8d51b5bf974afad2a4',
+                        name: 'Test Member',
+                        email: 'test@example.com',
+                        created_at: '2019-10-03T11:54:10.123Z',
+                        updated_at: '2019-10-03T11:54:10.123Z',
+                        newsletters: [{
+                            id: 'one'
+                        }, {
+                            id: 'two'
+                        }]
+                    }]
+                });
+
+                return appTester(App.creates.update_member.operation.perform, bundle)
+                    .then((member) => {
+                        apiMock.isDone().should.be.true;
+
+                        member.id.should.equal('5c9c9c8d51b5bf974afad2a4');
+                        member.newsletters.length.should.equal(2);
+                    });
+            });
+
+            it('unsubscribes a member from all newsletters when none are selected', function () {
+                let bundle = Object.assign({}, {authData}, {
+                    inputData: {
+                        id: '5c9c9c8d51b5bf974afad2a4',
+                        newsletter_count: 'multiple',
+                        newsletters_keepsame: false
+                    }
+                });
+
+                apiMock.put('/ghost/api/v3/admin/members/5c9c9c8d51b5bf974afad2a4/', {
+                    members: [{
+                        newsletters: []
+                    }]
+                }).reply(200, {
+                    members: [{
+                        id: '5c9c9c8d51b5bf974afad2a4',
+                        name: 'Test Member',
+                        email: 'test@example.com',
+                        created_at: '2019-10-03T11:54:10.123Z',
+                        updated_at: '2019-10-03T11:54:10.123Z',
+                        newsletters: []
+                    }]
+                });
+
+                return appTester(App.creates.update_member.operation.perform, bundle)
+                    .then((member) => {
+                        apiMock.isDone().should.be.true;
+
+                        member.id.should.equal('5c9c9c8d51b5bf974afad2a4');
+                        member.newsletters.length.should.equal(0);
+                    });
+            });
+
+            it('keeps existing newsletters when keepsame flag is set', function () {
+                let bundle = Object.assign({}, {authData}, {
+                    inputData: {
+                        id: '5c9c9c8d51b5bf974afad2a4',
+                        name: 'Test Member',
+                        newsletter_count: 'multiple',
+                        newsletters_keepsame: true,
+                        newsletters: ['one', 'two']
+                    }
+                });
+
+                apiMock.put('/ghost/api/v3/admin/members/5c9c9c8d51b5bf974afad2a4/', {
+                    members: [{
+                        name: 'Test Member'
+                    }]
+                }).reply(200, {
+                    members: [{
+                        id: '5c9c9c8d51b5bf974afad2a4',
+                        name: 'Test Member',
+                        email: 'test@example.com',
+                        created_at: '2019-10-03T11:54:10.123Z',
+                        updated_at: '2019-10-03T11:54:10.123Z'
+                    }]
+                });
+
+                return appTester(App.creates.update_member.operation.perform, bundle)
+                    .then((member) => {
+                        apiMock.isDone().should.be.true;
+
+                        member.id.should.equal('5c9c9c8d51b5bf974afad2a4');
+                        member.name.should.equal('Test Member');
+                    });
+            });
+        });
+
+        describe('with unsupported version < 5.0.0', function () {
+            beforeEach(function () {
+                apiMock.get('/ghost/api/v2/admin/site/').reply(200, {
+                    site: {version: '4.46'}
+                });
+            });
+
+            it('has a friendly, halting "unsupported version" error for newsletters', function () {
+                let bundle = Object.assign({}, {authData}, {
+                    inputData: {
+                        id: '5c9c9c8d51b5bf974afad2a4',
+                        newsletter_count: 'multiple',
+                        newsletters_keepsame: false,
+                        newsletters: []
+                    }
+                });
+
+                return appTester(App.creates.update_member.operation.perform, bundle)
+                    .then(() => {
+                        true.should.equal(false);
+                    }, (err) => {
+                        err.name.should.eql('HaltedError');
+                        err.message.should.match(/5\.0/);
+                    });
+            });
+        });
+
+        describe('dynamic input fields', function () {
+            // indexes of the dynamic field functions within operation.inputFields
+            const SUBSCRIPTION_FIELD = 5;
+            const NEWSLETTERS_FIELD = 6;
+
+            it('shows the subscribed field for a single newsletter', function () {
+                let bundle = Object.assign({}, {authData}, {
+                    inputData: {
+                        newsletter_count: 'single'
+                    }
+                });
+
+                return appTester(App.creates.update_member.operation.inputFields[SUBSCRIPTION_FIELD], bundle)
+                    .then(([field]) => {
+                        field.key.should.eql('subscribed');
+                        field.type.should.eql('boolean');
+                    });
+            });
+
+            it('shows the keepsame field for multiple newsletters', function () {
+                let bundle = Object.assign({}, {authData}, {
+                    inputData: {
+                        newsletter_count: 'multiple'
+                    }
+                });
+
+                return appTester(App.creates.update_member.operation.inputFields[SUBSCRIPTION_FIELD], bundle)
+                    .then(([field]) => {
+                        field.key.should.eql('newsletters_keepsame');
+                        field.required.should.eql(true);
+                    });
+            });
+
+            it('shows no subscription field before a newsletter count is chosen', function () {
+                let bundle = Object.assign({}, {authData}, {
+                    inputData: {}
+                });
+
+                return appTester(App.creates.update_member.operation.inputFields[SUBSCRIPTION_FIELD], bundle)
+                    .then((fields) => {
+                        fields.length.should.eql(0);
+                    });
+            });
+
+            it('shows the newsletters field when keepsame is disabled', function () {
+                let bundle = Object.assign({}, {authData}, {
+                    inputData: {
+                        newsletter_count: 'multiple',
+                        newsletters_keepsame: false
+                    }
+                });
+
+                return appTester(App.creates.update_member.operation.inputFields[NEWSLETTERS_FIELD], bundle)
+                    .then(([field]) => {
+                        field.key.should.eql('newsletters');
+                        field.list.should.eql(true);
+                    });
+            });
+
+            it('hides the newsletters field for a single newsletter', function () {
+                let bundle = Object.assign({}, {authData}, {
+                    inputData: {
+                        newsletter_count: 'single'
+                    }
+                });
+
+                return appTester(App.creates.update_member.operation.inputFields[NEWSLETTERS_FIELD], bundle)
+                    .then((fields) => {
+                        fields.length.should.eql(0);
                     });
             });
         });

--- a/test/lib/utils.test.js
+++ b/test/lib/utils.test.js
@@ -57,6 +57,29 @@ describe('Utils', function () {
             });
         });
 
+        it('falls back to the error message when a halted error has no context', function () {
+            const z = buildZ({
+                status: 404,
+                json: {
+                    errors: [{
+                        message: 'Resource not found error, cannot read member.',
+                        context: null,
+                        type: 'NotFoundError',
+                        code: null
+                    }]
+                }
+            });
+
+            const api = initAdminApi(z, authData);
+
+            return api.site.read().then(() => {
+                true.should.eql(false);
+            }, (err) => {
+                err.name.should.eql('HaltedError');
+                err.message.should.eql('Resource not found error, cannot read member. (NotFoundError)');
+            });
+        });
+
         it('includes the error code in halted validation errors', function () {
             const z = buildZ({
                 status: 422,

--- a/test/lib/utils.test.js
+++ b/test/lib/utils.test.js
@@ -1,0 +1,83 @@
+require('should');
+
+const {initAdminApi} = require('../../app/lib/utils');
+const packageVersion = require('../../package.json').version;
+
+class FakeHaltedError extends Error {
+    constructor(message) {
+        super(message);
+        this.name = 'HaltedError';
+    }
+}
+
+const authData = {
+    adminApiUrl: 'http://zapier-test.ghost.io',
+    adminApiKey: '5c3e1182e79eace7f58c9c3b:7202e874ccae6f1ee6688bb700f356b672fb078d8465860852652037f7c7459ddbd2f2a6e9aa05a40b499ae20027d9f9ba2e5004aa9ab6510b90a5dac674cbc1'
+};
+
+const buildZ = (response) => {
+    const z = {
+        requestOptions: null,
+        request(options) {
+            z.requestOptions = options;
+            return Promise.resolve(response);
+        },
+        errors: {HaltedError: FakeHaltedError}
+    };
+
+    return z;
+};
+
+describe('Utils', function () {
+    describe('initAdminApi', function () {
+        it('sets a plain Zapier User-Agent when the SDK sends none', function () {
+            const z = buildZ({
+                status: 200,
+                json: {site: {version: '5.0'}}
+            });
+
+            const api = initAdminApi(z, authData, {userAgent: false});
+
+            return api.site.read().then((site) => {
+                site.version.should.eql('5.0');
+                z.requestOptions.headers['User-Agent'].should.eql(`Zapier/${packageVersion}`);
+            });
+        });
+
+        it('prefixes the SDK User-Agent with the Zapier version', function () {
+            const z = buildZ({
+                status: 200,
+                json: {site: {version: '5.0'}}
+            });
+
+            const api = initAdminApi(z, authData);
+
+            return api.site.read().then(() => {
+                z.requestOptions.headers['User-Agent'].should.match(new RegExp(`^Zapier/${packageVersion} GhostAdminSDK/\\d+\\.\\d+\\.\\d+$`));
+            });
+        });
+
+        it('includes the error code in halted validation errors', function () {
+            const z = buildZ({
+                status: 422,
+                json: {
+                    errors: [{
+                        message: 'Validation error, cannot save member.',
+                        context: 'Validation failed for email',
+                        type: 'ValidationError',
+                        code: 'UNIQUE_EMAIL'
+                    }]
+                }
+            });
+
+            const api = initAdminApi(z, authData);
+
+            return api.site.read().then(() => {
+                true.should.eql(false);
+            }, (err) => {
+                err.name.should.eql('HaltedError');
+                err.message.should.eql('Validation failed for email (ValidationError: UNIQUE_EMAIL)');
+            });
+        });
+    });
+});

--- a/test/searches/author.test.js
+++ b/test/searches/author.test.js
@@ -8,7 +8,7 @@ const App = require('../../index');
 const appTester = zapier.createAppTester(App);
 
 describe('Searches', function () {
-    describe('Subscriber', function () {
+    describe('Author', function () {
         let apiMock, authData;
 
         beforeEach(function () {
@@ -148,6 +148,39 @@ describe('Searches', function () {
                     apiMock.isDone().should.be.true;
                     results.length.should.eql(0);
                 });
+        });
+
+        describe('dynamic input fields', function () {
+            // index of the dynamic field function within operation.inputFields
+            const SEARCH_TERM_FIELD = 1;
+
+            it('shows the email field when searching by email', function () {
+                let bundle = Object.assign({}, {authData}, {
+                    inputData: {
+                        search_by: 'email'
+                    }
+                });
+
+                return appTester(App.searches.author.operation.inputFields[SEARCH_TERM_FIELD], bundle)
+                    .then(([field]) => {
+                        field.key.should.eql('email');
+                        field.required.should.eql(true);
+                    });
+            });
+
+            it('shows the slug field when searching by slug', function () {
+                let bundle = Object.assign({}, {authData}, {
+                    inputData: {
+                        search_by: 'slug'
+                    }
+                });
+
+                return appTester(App.searches.author.operation.inputFields[SEARCH_TERM_FIELD], bundle)
+                    .then(([field]) => {
+                        field.key.should.eql('slug');
+                        field.required.should.eql(true);
+                    });
+            });
         });
 
         it('handles a validation error', function () {

--- a/test/searches/member.test.js
+++ b/test/searches/member.test.js
@@ -59,6 +59,49 @@ describe('Searches', function () {
                 });
         });
 
+        it('fetches a member from a paginated response', function () {
+            apiMock.get('/ghost/api/v2/admin/site/').reply(200, {
+                site: {version: '3.18.0'}
+            });
+
+            let bundle = Object.assign({}, {authData}, {
+                inputData: {
+                    email: 'ghost-member@example.com'
+                }
+            });
+
+            // when the response includes pagination meta the admin-api SDK
+            // returns an array which must not get double-wrapped
+            apiMock.get(`/ghost/api/v3/admin/members/?filter=email:'ghost-member%40example.com'`)
+                .reply(200, {
+                    members: [{
+                        id: '5951f5fca366002ebd5dbef7',
+                        name: 'Ghost',
+                        email: 'ghost-member@example.com'
+                    }],
+                    meta: {
+                        pagination: {
+                            page: 1,
+                            limit: 15,
+                            pages: 1,
+                            total: 1,
+                            next: null,
+                            prev: null
+                        }
+                    }
+                });
+
+            return appTester(App.searches.member.operation.perform, bundle)
+                .then((results) => {
+                    apiMock.isDone().should.be.true;
+                    results.length.should.eql(1);
+
+                    let [member] = results;
+                    member.id.should.eql('5951f5fca366002ebd5dbef7');
+                    member.email.should.eql('ghost-member@example.com');
+                });
+        });
+
         it('handles a 404', function () {
             apiMock.get('/ghost/api/v2/admin/site/').reply(200, {
                 site: {version: '3.18.0'}
@@ -88,6 +131,40 @@ describe('Searches', function () {
                 .then((results) => {
                     apiMock.isDone().should.be.true;
                     results.length.should.eql(0);
+                });
+        });
+
+        it('rethrows errors that are not a 404', function () {
+            apiMock.get('/ghost/api/v2/admin/site/').reply(200, {
+                site: {version: '3.18.0'}
+            });
+
+            let bundle = Object.assign({}, {authData}, {
+                inputData: {
+                    email: 'ghost-member@example.com'
+                }
+            });
+
+            apiMock.get(`/ghost/api/v3/admin/members/?filter=email:'ghost-member@example.com'`)
+                .reply(500, {
+                    errors: [{
+                        message: 'Authorization failed',
+                        context: 'Unable to determine the authenticated user or integration. Check that cookies are being passed through if using session authentication.',
+                        type: 'NoPermissionError',
+                        details: null,
+                        property: null,
+                        help: null,
+                        code: null,
+                        id: '34950f70-5148-11e9-9864-f79cf99013d0'
+                    }]
+                });
+
+            return appTester(App.searches.member.operation.perform, bundle)
+                .then(() => {
+                    true.should.eql(false);
+                }, (err) => {
+                    err.name.should.eql('RequestError');
+                    err.message.should.match(/Authorization failed/);
                 });
         });
 

--- a/test/searches/member.test.js
+++ b/test/searches/member.test.js
@@ -113,7 +113,7 @@ describe('Searches', function () {
                 }
             });
 
-            apiMock.get(`/ghost/api/v3/admin/members/?filter=email:'do-not-exist@example.com'`)
+            apiMock.get(`/ghost/api/v3/admin/members/?filter=email:'do-not-exist%40example.com'`)
                 .reply(404, {
                     errors: [{
                         message: 'Resource not found error, cannot read member.',
@@ -145,7 +145,7 @@ describe('Searches', function () {
                 }
             });
 
-            apiMock.get(`/ghost/api/v3/admin/members/?filter=email:'ghost-member@example.com'`)
+            apiMock.get(`/ghost/api/v3/admin/members/?filter=email:'ghost-member%40example.com'`)
                 .reply(500, {
                     errors: [{
                         message: 'Authorization failed',

--- a/test/triggers/author_created.test.js
+++ b/test/triggers/author_created.test.js
@@ -1,0 +1,191 @@
+require('should');
+const nock = require('nock');
+
+const zapier = require('zapier-platform-core');
+
+// Use this to make test calls into your app:
+const App = require('../../index');
+const appTester = zapier.createAppTester(App);
+
+const sampleAuthor = {
+    slug: 'ghost',
+    id: '5951f5fca366002ebd5dbef7',
+    name: 'Ghost',
+    email: 'ghost-author@example.com',
+    profile_image: 'https://static.ghost.org/v2.0.0/images/ghost.png',
+    cover_image: null,
+    bio: 'You can delete this user to remove all the welcome posts',
+    website: 'https://ghost.org',
+    location: 'The Internet',
+    facebook: 'ghost',
+    twitter: 'tryghost',
+    accessibility: null,
+    status: 'active',
+    meta_title: null,
+    meta_description: null,
+    tour: null,
+    last_seen: null,
+    created_at: '2019-01-08T14:49:40.000Z',
+    updated_at: '2019-01-08T14:49:40.000Z',
+    url: 'http://localhost:2368/author/ghost/'
+};
+
+describe('Triggers', function () {
+    describe('Author Created', function () {
+        let apiMock, authData;
+
+        beforeEach(function () {
+            apiMock = nock('http://zapier-test.ghost.io', {
+                reqheaders: {
+                    'User-Agent': new RegExp(`Zapier/${App.version} GhostAdminSDK/\\d+.\\d+.\\d+`)
+                }
+            });
+            authData = {
+                adminApiUrl: 'http://zapier-test.ghost.io',
+                adminApiKey: '5c3e1182e79eace7f58c9c3b:7202e874ccae6f1ee6688bb700f356b672fb078d8465860852652037f7c7459ddbd2f2a6e9aa05a40b499ae20027d9f9ba2e5004aa9ab6510b90a5dac674cbc1'
+            };
+        });
+
+        afterEach(function () {
+            nock.cleanAll();
+        });
+
+        it('loads author from webhook data', function () {
+            let bundle = Object.assign({}, {authData}, {
+                inputData: {},
+                cleanedRequest: {
+                    user: {
+                        current: sampleAuthor,
+                        previous: {}
+                    }
+                }
+            });
+
+            return appTester(App.triggers.author_created.operation.perform, bundle)
+                .then(([author]) => {
+                    author.id.should.eql('5951f5fca366002ebd5dbef7');
+                    author.name.should.eql('Ghost');
+                    author.slug.should.eql('ghost');
+                });
+        });
+
+        it('loads latest author from list', function () {
+            let bundle = Object.assign({}, {authData}, {
+                inputData: {},
+                meta: {
+                    frontend: true
+                }
+            });
+
+            apiMock.get('/ghost/api/v2/admin/users/')
+                .query({
+                    order: 'created_at DESC',
+                    limit: 1
+                })
+                .reply(200, {
+                    users: [sampleAuthor],
+                    meta: {
+                        pagination: {
+                            page: 1,
+                            limit: 1,
+                            pages: 1,
+                            total: 1,
+                            next: null,
+                            prev: null
+                        }
+                    }
+                });
+
+            return appTester(App.triggers.author_created.operation.performList, bundle)
+                .then((results) => {
+                    apiMock.isDone().should.be.true;
+                    results.length.should.eql(1);
+
+                    let [firstAuthor] = results;
+                    firstAuthor.id.should.eql('5951f5fca366002ebd5dbef7');
+                    firstAuthor.name.should.eql('Ghost');
+                });
+        });
+
+        it('loads all authors when filling dynamic dropdown', function () {
+            let bundle = Object.assign({}, {authData}, {
+                inputData: {},
+                meta: {
+                    isFillingDynamicDropdown: true
+                }
+            });
+
+            apiMock.get('/ghost/api/v2/admin/users/')
+                .query({
+                    order: 'name DESC',
+                    limit: 'all'
+                })
+                .reply(200, {
+                    users: [sampleAuthor, Object.assign({}, sampleAuthor, {
+                        id: '5951f5fca366002ebd5dbef8',
+                        name: 'Second Author',
+                        slug: 'second-author'
+                    })],
+                    meta: {
+                        pagination: {
+                            page: 1,
+                            limit: 'all',
+                            pages: 1,
+                            total: 2,
+                            next: null,
+                            prev: null
+                        }
+                    }
+                });
+
+            return appTester(App.triggers.author_created.operation.performList, bundle)
+                .then((results) => {
+                    apiMock.isDone().should.be.true;
+                    results.length.should.eql(2);
+                });
+        });
+
+        it('subscribes to webhook', function () {
+            let bundle = Object.assign({}, {authData}, {
+                targetUrl: 'https://webooks.zapier.com/ghost/author_created'
+            });
+
+            apiMock.post('/ghost/api/v2/admin/webhooks/', {
+                webhooks: [{
+                    integration_id: '5c3e1182e79eace7f58c9c3b',
+                    target_url: 'https://webooks.zapier.com/ghost/author_created',
+                    event: 'user.added'
+                }]
+            }).reply(201, {
+                webhooks: [{
+                    id: '12345',
+                    target_url: 'https://webooks.zapier.com/ghost/author_created',
+                    event: 'user.added'
+                }]
+            });
+
+            return appTester(App.triggers.author_created.operation.performSubscribe, bundle)
+                .then(() => {
+                    apiMock.isDone().should.be.true;
+                });
+        });
+
+        it('unsubscribes from webhook', function () {
+            let bundle = Object.assign({}, {authData}, {
+                subscribeData: {
+                    id: '12345',
+                    target_url: 'https://webooks.zapier.com/ghost/author_created',
+                    event: 'user.added'
+                }
+            });
+
+            apiMock.delete('/ghost/api/v2/admin/webhooks/12345/')
+                .reply(204);
+
+            return appTester(App.triggers.author_created.operation.performUnsubscribe, bundle)
+                .then(() => {
+                    apiMock.isDone().should.be.true;
+                });
+        });
+    });
+});

--- a/test/triggers/newsletter_created.test.js
+++ b/test/triggers/newsletter_created.test.js
@@ -106,6 +106,57 @@ describe('Triggers', function () {
                     });
             });
 
+            it('loads all newsletters when filling dynamic dropdown', function () {
+                let bundle = Object.assign({}, {authData}, {
+                    inputData: {},
+                    meta: {
+                        isFillingDynamicDropdown: true
+                    }
+                });
+
+                apiMock.get('/ghost/api/v2/admin/newsletters/')
+                    .query({
+                        order: 'name DESC',
+                        limit: 'all'
+                    })
+                    .reply(200, {
+                        newsletters: [{
+                            id: '627be9e49278a3c9b09f8883',
+                            name: 'Default newsletter',
+                            description: 'Thoughts, stories and ideas.',
+                            slug: 'default-newsletter',
+                            created_at: '2019-03-22T08:39:02.890Z',
+                            updated_at: '2019-03-22T08:39:02.890Z'
+                        }, {
+                            id: '627be9e49278a3c9b09f8884',
+                            name: 'Weekly newsletter',
+                            description: 'A weekly roundup.',
+                            slug: 'weekly-newsletter',
+                            created_at: '2019-03-22T08:39:02.890Z',
+                            updated_at: '2019-03-22T08:39:02.890Z'
+                        }],
+                        meta: {
+                            pagination: {
+                                page: 1,
+                                limit: 'all',
+                                pages: 1,
+                                total: 2,
+                                next: null,
+                                prev: null
+                            }
+                        }
+                    });
+
+                return appTester(App.triggers.newsletter_created.operation.performList, bundle)
+                    .then((results) => {
+                        apiMock.isDone().should.be.true;
+                        results.length.should.eql(2);
+
+                        let [firstNewsletter] = results;
+                        firstNewsletter.name.should.eql('Default newsletter');
+                    });
+            });
+
             it('subscribes to webhook', function () {
                 let bundle = Object.assign({}, {authData}, {
                     targetUrl: 'https://webooks.zapier.com/ghost/newsletter'

--- a/test/triggers/post_scheduled.test.js
+++ b/test/triggers/post_scheduled.test.js
@@ -165,7 +165,7 @@ describe('Triggers', function () {
                 }
             });
 
-            return appTester(App.triggers.post_published.operation.perform, bundle)
+            return appTester(App.triggers.post_scheduled.operation.perform, bundle)
                 .then(([post]) => {
                     post.id.should.eql('5c936c15eac9f256dec0bb96');
                     post.authors.length.should.eql(1, 'no of authors');

--- a/test/triggers/tag_created.test.js
+++ b/test/triggers/tag_created.test.js
@@ -42,6 +42,8 @@ describe('Triggers', function () {
         });
 
         it('loads tag from webhook data', function () {
+            // app code reads `user` here — copy-paste from author_created;
+            // this test documents current behaviour (see PR #93)
             let bundle = Object.assign({}, {authData}, {
                 inputData: {},
                 cleanedRequest: {

--- a/test/triggers/tag_created.test.js
+++ b/test/triggers/tag_created.test.js
@@ -1,0 +1,182 @@
+require('should');
+const nock = require('nock');
+
+const zapier = require('zapier-platform-core');
+
+// Use this to make test calls into your app:
+const App = require('../../index');
+const appTester = zapier.createAppTester(App);
+
+const sampleTag = {
+    slug: 'getting-started',
+    id: '5c34b884ba522a02712f01e8',
+    name: 'Getting Started',
+    description: null,
+    feature_image: null,
+    visibility: 'public',
+    meta_title: null,
+    meta_description: null,
+    created_at: '2019-01-08T14:49:40.000Z',
+    updated_at: '2019-01-08T14:49:40.000Z',
+    url: 'http://localhost:2368/tag/getting-started/'
+};
+
+describe('Triggers', function () {
+    describe('Tag Created', function () {
+        let apiMock, authData;
+
+        beforeEach(function () {
+            apiMock = nock('http://zapier-test.ghost.io', {
+                reqheaders: {
+                    'User-Agent': new RegExp(`Zapier/${App.version} GhostAdminSDK/\\d+.\\d+.\\d+`)
+                }
+            });
+            authData = {
+                adminApiUrl: 'http://zapier-test.ghost.io',
+                adminApiKey: '5c3e1182e79eace7f58c9c3b:7202e874ccae6f1ee6688bb700f356b672fb078d8465860852652037f7c7459ddbd2f2a6e9aa05a40b499ae20027d9f9ba2e5004aa9ab6510b90a5dac674cbc1'
+            };
+        });
+
+        afterEach(function () {
+            nock.cleanAll();
+        });
+
+        it('loads tag from webhook data', function () {
+            let bundle = Object.assign({}, {authData}, {
+                inputData: {},
+                cleanedRequest: {
+                    user: {
+                        current: sampleTag,
+                        previous: {}
+                    }
+                }
+            });
+
+            return appTester(App.triggers.tag_created.operation.perform, bundle)
+                .then(([tag]) => {
+                    tag.id.should.eql('5c34b884ba522a02712f01e8');
+                    tag.name.should.eql('Getting Started');
+                    tag.slug.should.eql('getting-started');
+                });
+        });
+
+        it('loads latest tag from list', function () {
+            let bundle = Object.assign({}, {authData}, {
+                inputData: {},
+                meta: {
+                    frontend: true
+                }
+            });
+
+            apiMock.get('/ghost/api/v2/admin/tags/')
+                .query({
+                    order: 'created_at DESC',
+                    limit: 1
+                })
+                .reply(200, {
+                    tags: [sampleTag],
+                    meta: {
+                        pagination: {
+                            page: 1,
+                            limit: 1,
+                            pages: 1,
+                            total: 1,
+                            next: null,
+                            prev: null
+                        }
+                    }
+                });
+
+            return appTester(App.triggers.tag_created.operation.performList, bundle)
+                .then((results) => {
+                    apiMock.isDone().should.be.true;
+                    results.length.should.eql(1);
+
+                    let [firstTag] = results;
+                    firstTag.id.should.eql('5c34b884ba522a02712f01e8');
+                    firstTag.name.should.eql('Getting Started');
+                });
+        });
+
+        it('loads all tags when filling dynamic dropdown', function () {
+            let bundle = Object.assign({}, {authData}, {
+                inputData: {},
+                meta: {
+                    isFillingDynamicDropdown: true
+                }
+            });
+
+            apiMock.get('/ghost/api/v2/admin/tags/')
+                .query({
+                    order: 'name DESC',
+                    limit: 'all'
+                })
+                .reply(200, {
+                    tags: [sampleTag, Object.assign({}, sampleTag, {
+                        id: '5c34b884ba522a02712f01e9',
+                        name: 'Second Tag',
+                        slug: 'second-tag'
+                    })],
+                    meta: {
+                        pagination: {
+                            page: 1,
+                            limit: 'all',
+                            pages: 1,
+                            total: 2,
+                            next: null,
+                            prev: null
+                        }
+                    }
+                });
+
+            return appTester(App.triggers.tag_created.operation.performList, bundle)
+                .then((results) => {
+                    apiMock.isDone().should.be.true;
+                    results.length.should.eql(2);
+                });
+        });
+
+        it('subscribes to webhook', function () {
+            let bundle = Object.assign({}, {authData}, {
+                targetUrl: 'https://webooks.zapier.com/ghost/tag_created'
+            });
+
+            apiMock.post('/ghost/api/v2/admin/webhooks/', {
+                webhooks: [{
+                    integration_id: '5c3e1182e79eace7f58c9c3b',
+                    target_url: 'https://webooks.zapier.com/ghost/tag_created',
+                    event: 'tag.added'
+                }]
+            }).reply(201, {
+                webhooks: [{
+                    id: '12345',
+                    target_url: 'https://webooks.zapier.com/ghost/tag_created',
+                    event: 'tag.added'
+                }]
+            });
+
+            return appTester(App.triggers.tag_created.operation.performSubscribe, bundle)
+                .then(() => {
+                    apiMock.isDone().should.be.true;
+                });
+        });
+
+        it('unsubscribes from webhook', function () {
+            let bundle = Object.assign({}, {authData}, {
+                subscribeData: {
+                    id: '12345',
+                    target_url: 'https://webooks.zapier.com/ghost/tag_created',
+                    event: 'tag.added'
+                }
+            });
+
+            apiMock.delete('/ghost/api/v2/admin/webhooks/12345/')
+                .reply(204);
+
+            return appTester(App.triggers.tag_created.operation.performUnsubscribe, bundle)
+                .then(() => {
+                    apiMock.isDone().should.be.true;
+                });
+        });
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,6 +23,11 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
+"@bcoe/v8-coverage@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
+  integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
+
 "@ember-data/rfc395-data@^0.0.4":
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/@ember-data/rfc395-data/-/rfc395-data-0.0.4.tgz#ecb86efdf5d7733a76ff14ea651a1b0ed1f8a843"
@@ -57,6 +62,29 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
+"@istanbuljs/schema@^0.1.2", "@istanbuljs/schema@^0.1.3":
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.6.tgz#8dc9afa2ac1506cb1a58f89940f1c124446c8df3"
+  integrity sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==
+
+"@jridgewell/resolve-uri@^3.1.0":
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz#7a0ee601f60f99a20c7c7c5ff0c80388c1189bd6"
+  integrity sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==
+
+"@jridgewell/sourcemap-codec@^1.4.14":
+  version "1.5.5"
+  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz#6912b00d2c631c0d15ce1a7ab57cd657f2a8f8ba"
+  integrity sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==
+
+"@jridgewell/trace-mapping@^0.3.12":
+  version "0.3.31"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz#db15d6781c931f3a251a3dac39501c98a6082fd0"
+  integrity sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.1.0"
+    "@jridgewell/sourcemap-codec" "^1.4.14"
+
 "@kapouer/eslint-plugin-no-return-in-loop@1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@kapouer/eslint-plugin-no-return-in-loop/-/eslint-plugin-no-return-in-loop-1.0.0.tgz#9fdbe83deca12156c0b5fcbfae1f387e9f2baff5"
@@ -70,6 +98,11 @@
     axios "^0.27.0"
     form-data "^4.0.0"
     jsonwebtoken "^8.4.0"
+
+"@types/istanbul-lib-coverage@^2.0.1":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz#7739c232a1fee9b4d3ce8985f314c0c6d33549d7"
+  integrity sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==
 
 "@types/node@^14.14.35":
   version "14.17.2"
@@ -230,6 +263,24 @@ builtin-modules@^3.0.0:
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-3.3.0.tgz#cae62812b89801e9656336e46223e030386be7b6"
   integrity sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==
 
+c8@^7.14.0:
+  version "7.14.0"
+  resolved "https://registry.yarnpkg.com/c8/-/c8-7.14.0.tgz#f368184c73b125a80565e9ab2396ff0be4d732f3"
+  integrity sha512-i04rtkkcNcCf7zsQcSv/T9EbUn4RXQ6mropeMcjFOsQXQ0iGLAr/xT6TImQg4+U9hmNpN9XdvPkjUL1IzbgxJw==
+  dependencies:
+    "@bcoe/v8-coverage" "^0.2.3"
+    "@istanbuljs/schema" "^0.1.3"
+    find-up "^5.0.0"
+    foreground-child "^2.0.0"
+    istanbul-lib-coverage "^3.2.0"
+    istanbul-lib-report "^3.0.0"
+    istanbul-reports "^3.1.4"
+    rimraf "^3.0.2"
+    test-exclude "^6.0.0"
+    v8-to-istanbul "^9.0.0"
+    yargs "^16.2.0"
+    yargs-parser "^20.2.9"
+
 callsites@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
@@ -335,6 +386,20 @@ content-disposition@0.5.3:
   integrity sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==
   dependencies:
     safe-buffer "5.1.2"
+
+convert-source-map@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-2.0.0.tgz#4b560f649fc4e918dd0ab75cf4961e8bc882d82a"
+  integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
+
+cross-spawn@^7.0.0:
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
+  integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==
+  dependencies:
+    path-key "^3.1.0"
+    shebang-command "^2.0.0"
+    which "^2.0.1"
 
 cross-spawn@^7.0.2:
   version "7.0.3"
@@ -681,7 +746,7 @@ fill-range@^7.0.1:
   dependencies:
     to-regex-range "^5.0.1"
 
-find-up@5.0.0:
+find-up@5.0.0, find-up@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-5.0.0.tgz#4c92819ecb7083561e4f4a240a86be5198f536fc"
   integrity sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==
@@ -719,6 +784,14 @@ follow-redirects@^1.14.9:
   version "1.15.0"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.0.tgz#06441868281c86d0dda4ad8bdaead2d02dca89d4"
   integrity sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ==
+
+foreground-child@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/foreground-child/-/foreground-child-2.0.0.tgz#71b32800c9f15aa8f2f83f4a6bd9bff35d861a53"
+  integrity sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==
+  dependencies:
+    cross-spawn "^7.0.0"
+    signal-exit "^3.0.2"
 
 form-data@4.0.0, form-data@^4.0.0:
   version "4.0.0"
@@ -792,6 +865,18 @@ glob@^7.1.3:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+glob@^7.1.4:
+  version "7.2.3"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
+  integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.1.1"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
 globals@^13.15.0:
   version "13.15.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-13.15.0.tgz#38113218c907d2f7e98658af246cef8b77e90bac"
@@ -825,6 +910,11 @@ hosted-git-info@^2.1.4:
   version "2.8.9"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.9.tgz#dffc0bf9a21c02209090f2aa69429e1414daf3f9"
   integrity sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==
+
+html-escaper@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
+  integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
 
 ignore@^5.1.1, ignore@^5.2.0:
   version "5.2.0"
@@ -939,6 +1029,28 @@ isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
+
+istanbul-lib-coverage@^3.0.0, istanbul-lib-coverage@^3.2.0:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz#2d166c4b0644d43a39f04bf6c2edd1e585f31756"
+  integrity sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==
+
+istanbul-lib-report@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz#908305bac9a5bd175ac6a74489eafd0fc2445a7d"
+  integrity sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==
+  dependencies:
+    istanbul-lib-coverage "^3.0.0"
+    make-dir "^4.0.0"
+    supports-color "^7.1.0"
+
+istanbul-reports@^3.1.4:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-3.2.0.tgz#cb4535162b5784aa623cee21a7252cf2c807ac93"
+  integrity sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==
+  dependencies:
+    html-escaper "^2.0.0"
+    istanbul-lib-report "^3.0.0"
 
 js-tokens@^4.0.0:
   version "4.0.0"
@@ -1129,6 +1241,13 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
+make-dir@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-4.0.0.tgz#c3c2307a771277cd9638305f915c29ae741b614e"
+  integrity sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==
+  dependencies:
+    semver "^7.5.3"
+
 mdn-data@2.0.27:
   version "2.0.27"
   resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.27.tgz#1710baa7b0db8176d3b3d565ccb7915fc69525ab"
@@ -1174,6 +1293,13 @@ minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
+  dependencies:
+    brace-expansion "^1.1.7"
+
+minimatch@^3.1.1:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.5.tgz#580c88f8d5445f2bd6aa8f3cadefa0de79fbd69e"
+  integrity sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==
   dependencies:
     brace-expansion "^1.1.7"
 
@@ -1521,6 +1647,11 @@ semver@^6.1.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
+semver@^7.5.3:
+  version "7.8.5"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.8.5.tgz#39b646037dd50c14fb451e7e4cac58ed8b863f69"
+  integrity sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==
+
 serialize-javascript@6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-6.0.0.tgz#efae5d88f45d7924141da8b5c3a7a7e663fefeb8"
@@ -1583,6 +1714,11 @@ should@13.2.3:
     should-type "^1.4.0"
     should-type-adaptors "^1.0.1"
     should-util "^1.0.0"
+
+signal-exit@^3.0.2:
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
+  integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
 
 snake-case@^3.0.3:
   version "3.0.3"
@@ -1693,6 +1829,15 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
+test-exclude@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-6.0.0.tgz#04a8698661d805ea6fa293b6cb9e63ac044ef15e"
+  integrity sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==
+  dependencies:
+    "@istanbuljs/schema" "^0.1.2"
+    glob "^7.1.4"
+    minimatch "^3.0.4"
+
 text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
@@ -1748,6 +1893,15 @@ v8-compile-cache@^2.0.3:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz#e14de37b31a6d194f5690d67efc4e7f6fc6ab30e"
   integrity sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==
+
+v8-to-istanbul@^9.0.0:
+  version "9.3.0"
+  resolved "https://registry.yarnpkg.com/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz#b9572abfa62bd556c16d75fdebc1a411d5ff3175"
+  integrity sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==
+  dependencies:
+    "@jridgewell/trace-mapping" "^0.3.12"
+    "@types/istanbul-lib-coverage" "^2.0.1"
+    convert-source-map "^2.0.0"
 
 validate-npm-package-license@^3.0.1:
   version "3.0.4"
@@ -1816,7 +1970,7 @@ yargs-parser@20.2.4:
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.4.tgz#b42890f14566796f85ae8e3a25290d205f154a54"
   integrity sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==
 
-yargs-parser@^20.2.2:
+yargs-parser@^20.2.2, yargs-parser@^20.2.9:
   version "20.2.9"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
   integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
@@ -1835,6 +1989,19 @@ yargs@16.2.0:
   version "16.2.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-16.2.0.tgz#1c82bf0f6b6a66eafce7ef30e376f49a12477f66"
   integrity sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==
+  dependencies:
+    cliui "^7.0.2"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.0"
+    y18n "^5.0.5"
+    yargs-parser "^20.2.2"
+
+yargs@^16.2.0:
+  version "16.2.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-16.2.2.tgz#c56731dca0d2788ae0866dd3c83907d6bab85f7d"
+  integrity sha512-Nt9ZJjXTv5R8MHbqby/wXQ6Gi0Bb3TcYZkR1bzuL4yB2OxWPkXknz513gEF0GoA6tn00UpbPvERW8rzCuWCA6w==
   dependencies:
     cliui "^7.0.2"
     escalade "^3.1.1"


### PR DESCRIPTION
ref [GVA-831](https://linear.app/ghost/issue/GVA-831/clean-repos-zapier)

Stacked on #92 (`gva-831/1-fix-ci-workflow`). Part 2 of the Clean Repos CI-trust remediation: make the test suite prove real breakage before CI is trusted for automated dependency updates.

## What was untested before

- **The entire Create Post action** — `perform` (html→mobiledoc source conversion, tag/author slug mapping, `?source=html` query param) and both dynamic input field functions had zero coverage. A regression in post creation would have shipped silently.
- **Tag Created and Author Created triggers** — no test file at all: browse queries, dynamic-dropdown variants, webhook subscribe/unsubscribe, webhook payload parsing.
- **Update Member's multi-newsletter path** (Ghost ≥ 5.0): newsletter id mapping, unsubscribe-from-all default, keepsame short-circuit, version gate.
- Dynamic input field functions on Create/Update Member and the author search.
- Member search array/rethrow branches, `utils.js` User-Agent and error-code branches, newsletter dropdown listing.
- The Post Scheduled webhook test accidentally invoked `post_published`'s perform, so `post_scheduled`'s webhook parsing was at 0% while appearing tested — fixed.

## Coverage

Measured with `npx c8 --include 'app/**/*.js' --include index.js --all mocha --recursive`:

| Metric | Baseline | Final |
| --- | --- | --- |
| Lines | 92.24% | 100% |
| Statements | 92.24% | 100% |
| Branches | 92.20% | 100% |
| Functions | **76.78%** (43/56) | 100% |

Tests: 98 → **140** passing.

## Coverage tooling

- `yarn test` now runs `c8 mocha --recursive` with `check-coverage` at **80/80/80/80** (lines/statements/branches/functions) via `.c8rc.json`, so CI fails when coverage drops below the gate.
- **c8 pinned to v7** (`^7.14.0`): the repo declares `node >=14.x` (i.e. 14.0) in `engines`. c8's Node floors are v8 `>=12`, v9 `>=14.14.0`, v10 `>=18`. CI's Node 14 leg runs a late 14.21.x that would satisfy c8@9's 14.14 floor, but `^7` is the conservative choice against the declared 14.0 minimum. Unpin when the Node floor rises (a core upgrade is planned later in this run).
- `coverage/` added to `.gitignore`.

## Notes

- `tag_created`'s webhook perform reads `bundle.cleanedRequest.user` in the app code (looks like a copy-paste from `author_created`; Ghost sends `tag` for `tag.added`). The trigger is hidden and only used for dynamic dropdowns via `performList`, so the test documents the actual behaviour rather than changing app code in a test-only PR.
- No changes to `.github/workflows/test.yml` (PR 1/PR 3 territory) and no e2e tests (PR 3).

## Commands run

```
yarn
yarn lint                     # clean
yarn test                     # 140 passing, gate satisfied
npx mocha --recursive         # 140 passing without coverage wrapper
```

