### PR TITLE
Add real-Ghost e2e suite and Required checks pass aggregator

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,3 +66,12 @@ jobs:
         if: failure()
         run: docker logs ghost
 
+  all-tests-pass:
+    name: All tests pass
+    if: always()
+    needs: [build, e2e]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all required jobs succeeded
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,8 @@ jobs:
     name: Node ${{ matrix.node }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ matrix.node }}
@@ -27,41 +29,55 @@ jobs:
 
   e2e:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     name: E2E (real Ghost)
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          repository: TryGhost/Ghost
+          ref: main
+          path: Ghost
+          # the default theme lives in a submodule and Ghost needs it to boot
+          submodules: true
+          persist-credentials: false
+      # Node version follows Ghost's engines (^22.18.0); the Zapier app
+      # itself is tested on its full matrix in the build job
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: '20'
+          node-version: '22.18.0'
           cache: yarn
+      - name: Install Corepack
+        run: npm install --global corepack@0.34.6
+      - name: Enable corepack
+        run: corepack enable
+      - name: Get pnpm store directory
+        id: pnpm-store
+        working-directory: Ghost
+        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('Ghost/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+      - name: Install Ghost dependencies
+        working-directory: Ghost
+        run: pnpm install --frozen-lockfile --filter ghost...
       - run: yarn
-      # if a future ghost:6 bump hard-blocks sqlite, switch to a mysql:8 service
-      - name: Start Ghost
-        run: >
-          docker run -d --name ghost -p 2368:2368
-          -e url=http://localhost:2368
-          -e database__client=sqlite3
-          -e database__connection__filename=/var/lib/ghost/content/data/ghost-test.db
-          -e database__useNullAsDefault=true
-          ghost:5
-      - name: Wait for Ghost
-        run: |
-          for i in $(seq 1 60); do
-            if curl -sf -o /dev/null http://localhost:2368/ghost/api/admin/site/; then
-              exit 0
-            fi
-            sleep 2
-          done
-          echo "Ghost did not become ready within 120s"
-          docker logs ghost
-          exit 1
+      - name: Start Ghost from source
+        run: ./test-e2e/setup/start-ghost.sh
+        env:
+          GHOST_CORE_PATH: ${{ github.workspace }}/Ghost
+          GHOST_LOG_FILE: ${{ runner.temp }}/ghost-boot.log
       - name: Bootstrap Ghost owner and integration
         run: node test-e2e/setup/bootstrap.js
       - run: yarn test:e2e
       - name: Dump Ghost logs
         if: failure()
-        run: docker logs ghost
+        run: cat "${{ runner.temp }}/ghost-boot.log"
 
   all-tests-pass:
     name: All tests pass

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,13 +4,11 @@ on:
   push:
     branches:
       - main
-      - 'renovate/*'
 permissions:
   contents: read
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && !startsWith(github.head_ref, 'renovate/'))
     timeout-minutes: 10
     strategy:
       fail-fast: false
@@ -29,7 +27,6 @@ jobs:
 
   e2e:
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && !startsWith(github.head_ref, 'renovate/'))
     timeout-minutes: 15
     name: E2E (real Ghost)
     steps:
@@ -73,5 +70,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Verify all required jobs succeeded
-        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
         run: exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
       - 'renovate/*'
+permissions:
+  contents: read
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -24,3 +26,43 @@ jobs:
       - run: yarn
       - run: yarn lint
       - run: yarn test
+
+  e2e:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && !startsWith(github.head_ref, 'renovate/'))
+    timeout-minutes: 15
+    name: E2E (real Ghost)
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '20'
+          cache: yarn
+      - run: yarn
+      # if a future ghost:6 bump hard-blocks sqlite, switch to a mysql:8 service
+      - name: Start Ghost
+        run: >
+          docker run -d --name ghost -p 2368:2368
+          -e url=http://localhost:2368
+          -e database__client=sqlite3
+          -e database__connection__filename=/var/lib/ghost/content/data/ghost-test.db
+          -e database__useNullAsDefault=true
+          ghost:5
+      - name: Wait for Ghost
+        run: |
+          for i in $(seq 1 60); do
+            if curl -sf -o /dev/null http://localhost:2368/ghost/api/admin/site/; then
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "Ghost did not become ready within 120s"
+          docker logs ghost
+          exit 1
+      - name: Bootstrap Ghost owner and integration
+        run: node test-e2e/setup/bootstrap.js
+      - run: yarn test:e2e
+      - name: Dump Ghost logs
+        if: failure()
+        run: docker logs ghost
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,8 +79,8 @@ jobs:
         if: failure()
         run: cat "${{ runner.temp }}/ghost-boot.log"
 
-  all-tests-pass:
-    name: All tests pass
+  required-checks-pass:
+    name: Required checks pass
     if: always()
     needs: [build, e2e]
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 .env
 .eslintcache
 coverage
+test-e2e/.env.local

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ test-e2e/.env.local
 # local Ghost checkout + runtime files used by the e2e suite
 /Ghost
 ghost.pid
+ghost-e2e.db

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ node_modules
 .eslintcache
 coverage
 test-e2e/.env.local
+# local Ghost checkout + runtime files used by the e2e suite
+/Ghost
+ghost.pid

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "main": "index.js",
   "scripts": {
     "lint": "eslint . --ext .js --cache",
-    "test": "c8 mocha --recursive"
+    "test": "c8 mocha --recursive",
+    "test:e2e": "mocha test-e2e --recursive --timeout 30000"
   },
   "engines": {
     "node": ">=14.x",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "scripts": {
     "lint": "eslint . --ext .js --cache",
     "test": "c8 mocha --recursive",
-    "test:e2e": "mocha test-e2e --recursive --timeout 30000"
+    "test:e2e": "./test-e2e/run.sh",
+    "test:e2e:bare": "mocha test-e2e --recursive --timeout 30000"
   },
   "engines": {
     "node": ">=14.x",

--- a/test-e2e/.eslintrc.js
+++ b/test-e2e/.eslintrc.js
@@ -1,0 +1,18 @@
+module.exports = {
+    env: {
+        es6: true,
+        node: true,
+        mocha: true
+    },
+    plugins: ['ghost'],
+    extends: ['plugin:ghost/test'],
+    overrides: [
+        {
+            // the bootstrap script is a CLI tool, its output is its interface
+            files: ['setup/bootstrap.js'],
+            rules: {
+                'no-console': 'off'
+            }
+        }
+    ]
+};

--- a/test-e2e/01-authentication.test.js
+++ b/test-e2e/01-authentication.test.js
@@ -1,0 +1,31 @@
+// Runs against a real Ghost instance - see test-e2e/setup/bootstrap.js
+require('should');
+
+const {App, appTester, getAuthData} = require('./helpers');
+const {OWNER} = require('./setup/bootstrap');
+
+describe('E2E Authentication', function () {
+    let authData;
+
+    before(function () {
+        authData = getAuthData();
+    });
+
+    it('succeeds with the bootstrapped Admin API key', async function () {
+        const result = await appTester(App.authentication.test, {authData});
+
+        result.blogTitle.should.equal(OWNER.blogTitle);
+        result.blogUrl.should.startWith(authData.adminApiUrl);
+    });
+
+    it('fails with an incorrect Admin API key secret', async function () {
+        const [keyId] = authData.adminApiKey.split(':');
+        const badAuthData = {
+            adminApiUrl: authData.adminApiUrl,
+            adminApiKey: `${keyId}:${'0'.repeat(64)}`
+        };
+
+        await appTester(App.authentication.test, {authData: badAuthData})
+            .should.be.rejected();
+    });
+});

--- a/test-e2e/01-authentication.test.js
+++ b/test-e2e/01-authentication.test.js
@@ -25,7 +25,10 @@ describe('E2E Authentication', function () {
             adminApiKey: `${keyId}:${'0'.repeat(64)}`
         };
 
+        // Ghost rejects the mis-signed token with "Invalid token: invalid
+        // signature" - matching on it proves a real credential rejection
+        // rather than any incidental failure (network, wrong URL, ...)
         await appTester(App.authentication.test, {authData: badAuthData})
-            .should.be.rejected();
+            .should.be.rejectedWith(/invalid token/i);
     });
 });

--- a/test-e2e/02-creates.test.js
+++ b/test-e2e/02-creates.test.js
@@ -1,0 +1,120 @@
+// Runs against a real Ghost instance - see test-e2e/setup/bootstrap.js
+require('should');
+
+const {App, appTester, getAuthData, fixtures} = require('./helpers');
+const {OWNER} = require('./setup/bootstrap');
+
+describe('E2E Creates', function () {
+    let authData;
+
+    before(function () {
+        authData = getAuthData();
+    });
+
+    describe('Create Member', function () {
+        it('creates a member without sending an email', async function () {
+            const member = await appTester(App.creates.create_member.operation.perform, {
+                authData,
+                inputData: {
+                    name: fixtures.member.name,
+                    email: fixtures.member.email,
+                    note: fixtures.member.note,
+                    newsletter_count: 'single',
+                    subscribed: true,
+                    // no mail transport is configured in CI, sending must stay off
+                    send_email: false
+                }
+            });
+
+            member.id.should.be.a.String();
+            member.email.should.equal(fixtures.member.email);
+            member.name.should.equal(fixtures.member.name);
+        });
+    });
+
+    describe('Update Member', function () {
+        it('updates the member with explicit newsletter subscriptions', async function () {
+            // the default newsletter every Ghost 5 site ships with
+            const [newsletter] = await appTester(App.triggers.newsletter_created.operation.performList, {
+                authData,
+                meta: {}
+            });
+            newsletter.id.should.be.a.String();
+
+            const [member] = await appTester(App.searches.member.operation.perform, {
+                authData,
+                inputData: {email: fixtures.member.email}
+            });
+
+            const updated = await appTester(App.creates.update_member.operation.perform, {
+                authData,
+                inputData: {
+                    id: member.id,
+                    name: `${fixtures.member.name} Updated`,
+                    newsletter_count: 'multiple',
+                    newsletters_keepsame: false,
+                    newsletters: [newsletter.id]
+                }
+            });
+
+            updated.id.should.equal(member.id);
+            updated.name.should.equal(`${fixtures.member.name} Updated`);
+            updated.newsletters.should.have.length(1);
+            updated.newsletters[0].id.should.equal(newsletter.id);
+        });
+    });
+
+    describe('Create Post', function () {
+        let ownerSlug;
+
+        before(async function () {
+            // the author input takes slugs - resolve the owner's real slug
+            // rather than guessing what Ghost generated from the name
+            const [owner] = await appTester(App.searches.author.operation.perform, {
+                authData,
+                inputData: {search_by: 'email', email: OWNER.email}
+            });
+            ownerSlug = owner.slug;
+        });
+
+        it('creates a published post from html source with a new tag', async function () {
+            const post = await appTester(App.creates.create_post.operation.perform, {
+                authData,
+                inputData: {
+                    title: fixtures.publishedPost.title,
+                    status: 'published',
+                    content_format: 'html',
+                    html: fixtures.publishedPost.html,
+                    tags: [fixtures.tagSlug],
+                    authors: [ownerSlug]
+                }
+            });
+
+            post.id.should.be.a.String();
+            post.title.should.equal(fixtures.publishedPost.title);
+            post.status.should.equal('published');
+            post.tags.should.have.length(1);
+            post.tags[0].slug.should.equal(fixtures.tagSlug);
+            post.primary_author.slug.should.equal(ownerSlug);
+        });
+
+        it('creates a scheduled post with a future publish date', async function () {
+            const oneHourAhead = new Date(Date.now() + (60 * 60 * 1000)).toISOString();
+
+            const post = await appTester(App.creates.create_post.operation.perform, {
+                authData,
+                inputData: {
+                    title: fixtures.scheduledPost.title,
+                    status: 'scheduled',
+                    published_at: oneHourAhead,
+                    content_format: 'html',
+                    html: fixtures.scheduledPost.html,
+                    authors: [ownerSlug]
+                }
+            });
+
+            post.status.should.equal('scheduled');
+            post.title.should.equal(fixtures.scheduledPost.title);
+        });
+    });
+});

--- a/test-e2e/03-searches.test.js
+++ b/test-e2e/03-searches.test.js
@@ -1,0 +1,74 @@
+// Runs against a real Ghost instance - see test-e2e/setup/bootstrap.js
+require('should');
+
+const {App, appTester, getAuthData, fixtures} = require('./helpers');
+const {OWNER} = require('./setup/bootstrap');
+
+describe('E2E Searches', function () {
+    let authData;
+
+    before(function () {
+        authData = getAuthData();
+    });
+
+    describe('Find a Member', function () {
+        it('finds the member seeded by the creates spec', async function () {
+            const results = await appTester(App.searches.member.operation.perform, {
+                authData,
+                inputData: {email: fixtures.member.email}
+            });
+
+            results.should.have.length(1);
+            results[0].email.should.equal(fixtures.member.email);
+            results[0].name.should.equal(`${fixtures.member.name} Updated`);
+        });
+
+        it('returns an empty array for an unknown email', async function () {
+            const results = await appTester(App.searches.member.operation.perform, {
+                authData,
+                inputData: {email: fixtures.missingEmail}
+            });
+
+            results.should.be.an.Array().and.have.length(0);
+        });
+    });
+
+    describe('Find an Author', function () {
+        it('finds the owner by email and again by the returned slug', async function () {
+            const byEmail = await appTester(App.searches.author.operation.perform, {
+                authData,
+                inputData: {search_by: 'email', email: OWNER.email}
+            });
+
+            byEmail.should.have.length(1);
+            byEmail[0].email.should.equal(OWNER.email);
+            byEmail[0].slug.should.be.a.String();
+
+            const bySlug = await appTester(App.searches.author.operation.perform, {
+                authData,
+                inputData: {search_by: 'slug', slug: byEmail[0].slug}
+            });
+
+            bySlug.should.have.length(1);
+            bySlug[0].email.should.equal(OWNER.email);
+        });
+
+        it('returns an empty array for an unknown email', async function () {
+            const results = await appTester(App.searches.author.operation.perform, {
+                authData,
+                inputData: {search_by: 'email', email: fixtures.missingEmail}
+            });
+
+            results.should.be.an.Array().and.have.length(0);
+        });
+
+        it('returns an empty array for an unknown slug', async function () {
+            const results = await appTester(App.searches.author.operation.perform, {
+                authData,
+                inputData: {search_by: 'slug', slug: fixtures.missingSlug}
+            });
+
+            results.should.be.an.Array().and.have.length(0);
+        });
+    });
+});

--- a/test-e2e/04-triggers.test.js
+++ b/test-e2e/04-triggers.test.js
@@ -1,0 +1,78 @@
+// Runs against a real Ghost instance - see test-e2e/setup/bootstrap.js
+require('should');
+
+const {App, appTester, getAuthData, fixtures} = require('./helpers');
+const {OWNER} = require('./setup/bootstrap');
+
+describe('E2E Trigger performLists', function () {
+    let authData;
+
+    const performList = (triggerKey) => {
+        return appTester(App.triggers[triggerKey].operation.performList, {authData, meta: {}});
+    };
+
+    before(function () {
+        authData = getAuthData();
+    });
+
+    it('post_published lists the latest published post', async function () {
+        const [post] = await performList('post_published');
+
+        post.title.should.equal(fixtures.publishedPost.title);
+        post.status.should.equal('published');
+        post.html.should.equal(fixtures.publishedPost.html);
+    });
+
+    it('post_scheduled lists the latest scheduled post', async function () {
+        const [post] = await performList('post_scheduled');
+
+        post.title.should.equal(fixtures.scheduledPost.title);
+        post.status.should.equal('scheduled');
+    });
+
+    it('page_published lists the latest published page', async function () {
+        // a fresh Ghost install ships with a published "About this site" page
+        const [page] = await performList('page_published');
+
+        page.status.should.equal('published');
+        page.title.should.be.a.String();
+    });
+
+    it('member_created lists the latest member', async function () {
+        const [member] = await performList('member_created');
+
+        member.email.should.equal(fixtures.member.email);
+    });
+
+    it('member_updated returns the static sample payload after a version check', async function () {
+        const results = await performList('member_updated');
+
+        results.should.have.length(1);
+        results[0].should.equal(App.triggers.member_updated.operation.sample);
+    });
+
+    it('member_deleted lists the latest member after a version check', async function () {
+        const [member] = await performList('member_deleted');
+
+        member.email.should.equal(fixtures.member.email);
+    });
+
+    it('newsletter_created lists the default newsletter', async function () {
+        const [newsletter] = await performList('newsletter_created');
+
+        newsletter.id.should.be.a.String();
+        newsletter.name.should.equal(OWNER.blogTitle);
+    });
+
+    it('tag_created lists the tag seeded via create_post', async function () {
+        const [tag] = await performList('tag_created');
+
+        tag.slug.should.equal(fixtures.tagSlug);
+    });
+
+    it('author_created lists the owner user', async function () {
+        const [author] = await performList('author_created');
+
+        author.email.should.equal(OWNER.email);
+    });
+});

--- a/test-e2e/05-webhooks.test.js
+++ b/test-e2e/05-webhooks.test.js
@@ -1,0 +1,45 @@
+// Runs against a real Ghost instance - see test-e2e/setup/bootstrap.js
+require('should');
+
+const {App, appTester, getAuthData} = require('./helpers');
+
+// every hook trigger that can subscribe against a modern Ghost - the
+// deprecated subscriber_* triggers are covered in 06-subscribers.test.js
+const HOOK_TRIGGERS = [
+    'post_published',
+    'post_scheduled',
+    'page_published',
+    'tag_created',
+    'author_created',
+    'member_created',
+    'member_updated',
+    'member_deleted',
+    'newsletter_created'
+];
+
+HOOK_TRIGGERS.forEach(function (triggerKey) {
+    describe(`E2E Webhook subscription: ${triggerKey}`, function () {
+        let authData;
+
+        before(function () {
+            authData = getAuthData();
+        });
+
+        it('completes a subscribe/unsubscribe round-trip', async function () {
+            const {operation} = App.triggers[triggerKey];
+
+            const subscribeData = await appTester(operation.performSubscribe, {
+                authData,
+                targetUrl: `http://example.com/hook/${triggerKey}`
+            });
+
+            subscribeData.id.should.be.a.String();
+
+            // a failed DELETE would reject and fail the test
+            await appTester(operation.performUnsubscribe, {
+                authData,
+                subscribeData
+            });
+        });
+    });
+});

--- a/test-e2e/06-subscribers.test.js
+++ b/test-e2e/06-subscribers.test.js
@@ -1,0 +1,49 @@
+// Runs against a real Ghost instance - see test-e2e/setup/bootstrap.js
+// Subscribers were removed in Ghost 3.0, so against a modern Ghost every
+// deprecated subscriber operation must halt with a version-gate error.
+require('should');
+
+const {App, appTester, getAuthData, shouldHalt, fixtures} = require('./helpers');
+
+const VERSION_GATE = /does not support subscribers/;
+
+describe('E2E Deprecated subscriber operations', function () {
+    let authData;
+
+    before(function () {
+        authData = getAuthData();
+    });
+
+    it('create_subscriber halts with a version-gate error', async function () {
+        await shouldHalt(appTester(App.creates.create_subscriber.operation.perform, {
+            authData,
+            inputData: {email: fixtures.member.email}
+        }), VERSION_GATE);
+    });
+
+    it('delete_subscriber halts with a version-gate error', async function () {
+        await shouldHalt(appTester(App.creates.delete_subscriber.operation.perform, {
+            authData,
+            inputData: {email: fixtures.member.email}
+        }), VERSION_GATE);
+    });
+
+    it('subscriber search halts with a version-gate error', async function () {
+        await shouldHalt(appTester(App.searches.subscriber.operation.perform, {
+            authData,
+            inputData: {email: fixtures.member.email}
+        }), VERSION_GATE);
+    });
+
+    it('subscriber_created performList halts with a version-gate error', async function () {
+        await shouldHalt(appTester(App.triggers.subscriber_created.operation.performList, {
+            authData
+        }), VERSION_GATE);
+    });
+
+    it('subscriber_deleted performList halts with a version-gate error', async function () {
+        await shouldHalt(appTester(App.triggers.subscriber_deleted.operation.performList, {
+            authData
+        }), VERSION_GATE);
+    });
+});

--- a/test-e2e/06-subscribers.test.js
+++ b/test-e2e/06-subscribers.test.js
@@ -41,6 +41,20 @@ describe('E2E Deprecated subscriber operations', function () {
         }), VERSION_GATE);
     });
 
+    it('subscriber_created performSubscribe halts with a version-gate error', async function () {
+        await shouldHalt(appTester(App.triggers.subscriber_created.operation.performSubscribe, {
+            authData,
+            targetUrl: 'http://example.com/hook/subscriber_created'
+        }), VERSION_GATE);
+    });
+
+    it('subscriber_created performUnsubscribe halts with a version-gate error', async function () {
+        await shouldHalt(appTester(App.triggers.subscriber_created.operation.performUnsubscribe, {
+            authData,
+            subscribeData: {id: '5c9c9c8d51b5bf974afad2a4'}
+        }), VERSION_GATE);
+    });
+
     it('subscriber_deleted performList halts with a version-gate error', async function () {
         await shouldHalt(appTester(App.triggers.subscriber_deleted.operation.performList, {
             authData

--- a/test-e2e/helpers.js
+++ b/test-e2e/helpers.js
@@ -20,8 +20,9 @@ const getAuthData = () => {
     if (!adminApiUrl || !adminApiKey) {
         throw new Error(
             'GHOST_ADMIN_API_URL and GHOST_ADMIN_API_KEY must be set. ' +
-            'Start a Ghost instance on http://localhost:2368 and run ' +
-            '`node test-e2e/setup/bootstrap.js` first.'
+            'Start a Ghost instance on http://localhost:2368, run ' +
+            '`node test-e2e/setup/bootstrap.js` and export the values it ' +
+            'writes to test-e2e/.env.local.'
         );
     }
 

--- a/test-e2e/helpers.js
+++ b/test-e2e/helpers.js
@@ -1,0 +1,76 @@
+const should = require('should');
+const zapier = require('zapier-platform-core');
+
+const App = require('../index');
+
+const appTester = zapier.createAppTester(App);
+
+/**
+ * Auth data pointing at the real Ghost instance bootstrapped by
+ * `test-e2e/setup/bootstrap.js`. Fails fast with a setup hint when the
+ * environment is missing so a bare `yarn test:e2e` doesn't produce a wall of
+ * confusing network errors.
+ *
+ * @returns {object} authData bundle fragment
+ */
+const getAuthData = () => {
+    const adminApiUrl = process.env.GHOST_ADMIN_API_URL;
+    const adminApiKey = process.env.GHOST_ADMIN_API_KEY;
+
+    if (!adminApiUrl || !adminApiKey) {
+        throw new Error(
+            'GHOST_ADMIN_API_URL and GHOST_ADMIN_API_KEY must be set. ' +
+            'Start a Ghost instance on http://localhost:2368 and run ' +
+            '`node test-e2e/setup/bootstrap.js` first.'
+        );
+    }
+
+    return {adminApiUrl, adminApiKey};
+};
+
+/**
+ * Asserts that a promise rejects with a HaltedError whose message matches.
+ *
+ * @param {Promise} promise the in-flight appTester call
+ * @param {RegExp} messagePattern expected error message
+ */
+const shouldHalt = async (promise, messagePattern) => {
+    const error = await promise.then(
+        () => should.fail('expected a HaltedError but the call succeeded'),
+        err => err
+    );
+
+    error.name.should.equal('HaltedError');
+    error.message.should.match(messagePattern);
+};
+
+// data seeded by 02-creates.test.js and asserted on by the search and
+// trigger specs - mocha loads the spec files in alphabetical order.
+// The suite assumes a freshly bootstrapped Ghost install (as in CI), so
+// restart the container before re-running locally.
+const fixtures = {
+    member: {
+        name: 'E2E Member',
+        email: 'e2e-member@example.com',
+        note: 'Created by the Zapier e2e suite'
+    },
+    publishedPost: {
+        title: 'E2E Published Post',
+        html: '<p>Published by the Zapier e2e suite.</p>'
+    },
+    scheduledPost: {
+        title: 'E2E Scheduled Post',
+        html: '<p>Scheduled by the Zapier e2e suite.</p>'
+    },
+    tagSlug: 'e2e-zapier',
+    missingEmail: 'e2e-does-not-exist@example.com',
+    missingSlug: 'e2e-does-not-exist'
+};
+
+module.exports = {
+    App,
+    appTester,
+    getAuthData,
+    shouldHalt,
+    fixtures
+};

--- a/test-e2e/helpers.js
+++ b/test-e2e/helpers.js
@@ -1,9 +1,32 @@
+const fs = require('fs');
+const {join} = require('path');
+
 const should = require('should');
 const zapier = require('zapier-platform-core');
 
 const App = require('../index');
 
 const appTester = zapier.createAppTester(App);
+
+/**
+ * Loads the credentials written by `test-e2e/setup/bootstrap.js` into the
+ * environment so a plain `yarn test:e2e` works locally without exporting
+ * anything by hand. Already-set variables (e.g. from $GITHUB_ENV in CI)
+ * always win over the file.
+ */
+const loadLocalEnv = () => {
+    const envFile = join(__dirname, '.env.local');
+    if (!fs.existsSync(envFile)) {
+        return;
+    }
+
+    for (const line of fs.readFileSync(envFile, 'utf8').split('\n')) {
+        const match = line.match(/^([A-Z0-9_]+)=(.*)$/);
+        if (match && !process.env[match[1]]) {
+            process.env[match[1]] = match[2];
+        }
+    }
+};
 
 /**
  * Auth data pointing at the real Ghost instance bootstrapped by
@@ -14,15 +37,19 @@ const appTester = zapier.createAppTester(App);
  * @returns {object} authData bundle fragment
  */
 const getAuthData = () => {
+    loadLocalEnv();
+
     const adminApiUrl = process.env.GHOST_ADMIN_API_URL;
     const adminApiKey = process.env.GHOST_ADMIN_API_KEY;
 
     if (!adminApiUrl || !adminApiKey) {
         throw new Error(
             'GHOST_ADMIN_API_URL and GHOST_ADMIN_API_KEY must be set. ' +
-            'Start a Ghost instance on http://localhost:2368, run ' +
-            '`node test-e2e/setup/bootstrap.js` and export the values it ' +
-            'writes to test-e2e/.env.local.'
+            'Start a Ghost instance on http://localhost:2368 (e.g. via ' +
+            '`test-e2e/setup/start-ghost.sh` with GHOST_CORE_PATH pointing ' +
+            'at a Ghost checkout) and run `node test-e2e/setup/bootstrap.js` ' +
+            'first - after that a plain `yarn test:e2e` picks the ' +
+            'credentials up from test-e2e/.env.local automatically.'
         );
     }
 

--- a/test-e2e/helpers.js
+++ b/test-e2e/helpers.js
@@ -45,11 +45,11 @@ const getAuthData = () => {
     if (!adminApiUrl || !adminApiKey) {
         throw new Error(
             'GHOST_ADMIN_API_URL and GHOST_ADMIN_API_KEY must be set. ' +
-            'Start a Ghost instance on http://localhost:2368 (e.g. via ' +
-            '`test-e2e/setup/start-ghost.sh` with GHOST_CORE_PATH pointing ' +
-            'at a Ghost checkout) and run `node test-e2e/setup/bootstrap.js` ' +
-            'first - after that a plain `yarn test:e2e` picks the ' +
-            'credentials up from test-e2e/.env.local automatically.'
+            'Run the suite via `yarn test:e2e` - with docker running (or ' +
+            'GHOST_CORE_PATH pointing at a Ghost checkout) it provisions a ' +
+            'fresh Ghost and bootstraps credentials automatically. To ' +
+            'manage Ghost yourself, start one and run ' +
+            '`node test-e2e/setup/bootstrap.js` first.'
         );
     }
 
@@ -74,8 +74,8 @@ const shouldHalt = async (promise, messagePattern) => {
 
 // data seeded by 02-creates.test.js and asserted on by the search and
 // trigger specs - mocha loads the spec files in alphabetical order.
-// The suite assumes a freshly bootstrapped Ghost install (as in CI), so
-// restart the container before re-running locally.
+// The suite assumes a freshly bootstrapped Ghost install; `yarn test:e2e`
+// provisions (and tears down) one per run automatically.
 const fixtures = {
     member: {
         name: 'E2E Member',

--- a/test-e2e/run.sh
+++ b/test-e2e/run.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Self-contained e2e runner - a bare `yarn test:e2e` should just work.
+#
+# Resolution order:
+# 1. GHOST_ADMIN_API_URL/GHOST_ADMIN_API_KEY exported (CI): run mocha
+#    directly, no lifecycle management
+# 2. test-e2e/.env.local pointing at a Ghost that still answers: reuse it
+# 3. GHOST_CORE_PATH set: boot Ghost from that source checkout
+# 4. docker available: boot a fresh ghost:6 container in development mode
+#    (development so Ghost accepts sqlite - no MySQL service needed)
+# 5. otherwise: explain the options
+#
+# Ghosts provisioned by 3 and 4 are fresh installs - the suite's fixtures
+# use fixed emails/titles, so re-running against seeded data would fail -
+# and are torn down afterwards whether mocha passes or fails. The script's
+# exit code is mocha's exit code.
+
+here="$(cd "$(dirname "$0")" && pwd)"
+root="$(cd "${here}/.." && pwd)"
+env_file="${here}/.env.local"
+container="zapier-e2e-ghost"
+
+cd "${root}"
+
+ghost_answers() {
+    curl -sf -o /dev/null "$1/ghost/api/admin/site/"
+}
+
+wait_for_ghost() {
+    for _ in $(seq 1 90); do
+        if ghost_answers "${ghost_url}"; then
+            return 0
+        fi
+        sleep 2
+    done
+    return 1
+}
+
+# prefer Ghost's usual port but fall back to an ephemeral one so the runner
+# also works next to a developer's own Ghost already sitting on 2368
+pick_free_port() {
+    node -e "
+        const net = require('net');
+        const server = net.createServer();
+        server.once('error', () => {
+            const fallback = net.createServer();
+            fallback.listen(0, () => {
+                console.log(fallback.address().port);
+                fallback.close();
+            });
+        });
+        server.listen(2368, () => {
+            server.close(() => console.log(2368));
+        });
+    "
+}
+
+# 1. explicit credentials (CI exports these via $GITHUB_ENV)
+if [ -n "${GHOST_ADMIN_API_URL:-}" ] && [ -n "${GHOST_ADMIN_API_KEY:-}" ]; then
+    exec yarn test:e2e:bare
+fi
+
+# 2. credentials from a previous bootstrap - reuse them if that Ghost is
+# still up, otherwise treat the file as stale and provision from scratch
+if [ -f "${env_file}" ]; then
+    url="$(sed -n 's/^GHOST_ADMIN_API_URL=//p' "${env_file}")"
+    if [ -n "${url}" ] && ghost_answers "${url}"; then
+        echo "Reusing the Ghost at ${url} (from test-e2e/.env.local)"
+        exec yarn test:e2e:bare
+    fi
+    echo "test-e2e/.env.local points at a Ghost that no longer answers - re-provisioning"
+    rm -f "${env_file}"
+fi
+
+# 3./4. self-provision a fresh Ghost and tear it down afterwards
+provisioned=""
+state_dir=""
+
+# shellcheck disable=SC2329 # invoked via the trap below
+teardown() {
+    if [ "${provisioned}" = "source" ] && [ -f "${state_dir}/ghost.pid" ]; then
+        kill "$(cat "${state_dir}/ghost.pid")" 2>/dev/null || true
+    fi
+    if [ "${provisioned}" = "docker" ]; then
+        docker rm -f "${container}" >/dev/null 2>&1 || true
+    fi
+    if [ -n "${state_dir}" ]; then
+        rm -rf "${state_dir}"
+    fi
+    rm -f "${env_file}"
+}
+trap teardown EXIT INT TERM
+
+port="$(pick_free_port)"
+ghost_url="http://localhost:${port}"
+
+if [ -n "${GHOST_CORE_PATH:-}" ]; then
+    provisioned="source"
+    state_dir="$(mktemp -d)"
+    GHOST_PORT="${port}" GHOST_LOG_FILE="${state_dir}/ghost-boot.log" "${here}/setup/start-ghost.sh"
+elif command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
+    provisioned="docker"
+    echo "Booting a fresh ghost:6 container ('${container}') on ${ghost_url}"
+    docker rm -f "${container}" >/dev/null 2>&1 || true
+    docker run -d --name "${container}" -p "${port}:2368" \
+        -e NODE_ENV=development \
+        -e url="${ghost_url}" \
+        -e database__client=sqlite3 \
+        -e database__connection__filename=/var/lib/ghost/content/data/ghost-e2e.db \
+        -e database__useNullAsDefault=true \
+        ghost:6 >/dev/null
+    if ! wait_for_ghost; then
+        echo "Ghost container did not become ready within 180s" >&2
+        docker logs "${container}" 2>&1 | tail -50 >&2
+        exit 1
+    fi
+    echo "Ghost is ready"
+else
+    cat >&2 <<'EOF'
+No Ghost to test against and no way to provision one. Pick one:
+  - start docker                    -> `yarn test:e2e` boots a throwaway ghost:6 container
+  - GHOST_CORE_PATH=/path/to/Ghost  -> boots Ghost from a source checkout
+                                       (needs `pnpm install --frozen-lockfile --filter ghost...`)
+  - run any fresh Ghost yourself    -> `node test-e2e/setup/bootstrap.js` (set GHOST_URL if it
+                                       is not on http://localhost:2368), then `yarn test:e2e`
+EOF
+    exit 1
+fi
+
+GHOST_URL="${ghost_url}" node "${here}/setup/bootstrap.js"
+
+set +e
+yarn test:e2e:bare
+status=$?
+set -e
+
+exit "${status}"

--- a/test-e2e/setup/bootstrap.js
+++ b/test-e2e/setup/bootstrap.js
@@ -11,14 +11,15 @@
  * are written to `test-e2e/.env.local` (gitignored) so the key never
  * appears in logs.
  *
- * Running the e2e suite locally:
- * 1. boot a fresh Ghost on http://localhost:2368 - either point
- *    GHOST_CORE_PATH at a TryGhost/Ghost checkout and run
- *    `test-e2e/setup/start-ghost.sh`, or start any Ghost yourself and set
- *    GHOST_URL if it lives elsewhere
- * 2. `node test-e2e/setup/bootstrap.js`
- * 3. `yarn test:e2e` - the suite picks the credentials up from
- *    test-e2e/.env.local automatically (already-set env vars win)
+ * Running the e2e suite locally: just `yarn test:e2e` - with docker
+ * running it provisions a throwaway ghost:6 container, runs this
+ * bootstrap and tears everything down again (see test-e2e/run.sh).
+ * Overrides:
+ * - GHOST_CORE_PATH=/path/to/Ghost boots Ghost from a source checkout
+ *   instead of docker (dependencies must be installed)
+ * - to manage Ghost yourself: start a fresh instance, run this script
+ *   directly (set GHOST_URL if it is not on http://localhost:2368), then
+ *   `yarn test:e2e` picks the credentials up from test-e2e/.env.local
  */
 const http = require('http');
 const fs = require('fs');

--- a/test-e2e/setup/bootstrap.js
+++ b/test-e2e/setup/bootstrap.js
@@ -128,6 +128,12 @@ const exportCredentials = (adminApiKey) => {
 };
 
 const bootstrap = async () => {
+    // the request helper uses the core http module, so a https:// (or
+    // otherwise non-http) URL would fail confusingly further down
+    if (!GHOST_URL.startsWith('http://')) {
+        throw new Error(`GHOST_URL must be an http:// URL (got '${GHOST_URL}') - this script only targets local/CI Ghost instances`);
+    }
+
     await createOwner();
     const sessionCookie = await createSession();
     const adminApiKey = await createIntegration(sessionCookie);

--- a/test-e2e/setup/bootstrap.js
+++ b/test-e2e/setup/bootstrap.js
@@ -1,0 +1,149 @@
+/**
+ * Bootstraps a fresh Ghost install for the e2e test suite.
+ *
+ * Runs the Ghost Admin setup flow over HTTP against a running instance:
+ * 1. creates the owner user (no auth required on a fresh install)
+ * 2. logs in with the owner credentials to obtain a session cookie
+ * 3. creates a "Zapier E2E" custom integration and extracts its Admin API key
+ *
+ * The resulting `GHOST_ADMIN_API_URL` and `GHOST_ADMIN_API_KEY` values are
+ * appended to `$GITHUB_ENV` when running in GitHub Actions, otherwise they
+ * are printed to stdout for local use.
+ *
+ * Usage: node test-e2e/setup/bootstrap.js
+ */
+const http = require('http');
+const fs = require('fs');
+
+const GHOST_URL = process.env.GHOST_URL || 'http://localhost:2368';
+
+const OWNER = {
+    name: 'Zapier E2E Owner',
+    email: 'zapier-e2e@example.com',
+    // Ghost requires passwords to be at least 10 characters long and rejects
+    // "insecure" ones (e.g. anything containing the word "password")
+    password: 'zapier-e2e-Gh0st',
+    blogTitle: 'Zapier E2E'
+};
+
+/**
+ * @param {string} method HTTP method
+ * @param {string} path request path relative to GHOST_URL
+ * @param {object} [options]
+ * @param {object} [options.body] JSON request body
+ * @param {object} [options.headers] additional request headers
+ * @returns {Promise<{status: number, headers: object, json: object}>}
+ */
+const request = (method, path, {body, headers = {}} = {}) => {
+    return new Promise((resolve, reject) => {
+        const payload = body ? JSON.stringify(body) : null;
+        const req = http.request(`${GHOST_URL}${path}`, {
+            method,
+            headers: Object.assign({
+                'Content-Type': 'application/json',
+                // Ghost's session API requires a matching Origin header
+                Origin: GHOST_URL
+            }, headers)
+        }, (res) => {
+            let raw = '';
+            res.on('data', chunk => (raw += chunk));
+            res.on('end', () => {
+                let json = null;
+                try {
+                    json = raw ? JSON.parse(raw) : null;
+                } catch (err) {
+                    // non-JSON body (e.g. empty 201 responses) - leave json as null
+                }
+                resolve({status: res.statusCode, headers: res.headers, json});
+            });
+        });
+
+        req.on('error', reject);
+
+        if (payload) {
+            req.write(payload);
+        }
+        req.end();
+    });
+};
+
+const assertStatus = (step, response, expected) => {
+    if (response.status !== expected) {
+        const detail = response.json ? JSON.stringify(response.json) : '(no body)';
+        throw new Error(`${step} failed: expected HTTP ${expected}, got ${response.status} - ${detail}`);
+    }
+};
+
+const createOwner = async () => {
+    const response = await request('POST', '/ghost/api/admin/authentication/setup/', {
+        body: {setup: [OWNER]}
+    });
+    assertStatus('Owner setup', response, 201);
+};
+
+const createSession = async () => {
+    const response = await request('POST', '/ghost/api/admin/session/', {
+        body: {username: OWNER.email, password: OWNER.password}
+    });
+    assertStatus('Session login', response, 201);
+
+    const cookies = response.headers['set-cookie'];
+    if (!cookies || cookies.length === 0) {
+        throw new Error('Session login did not return a session cookie');
+    }
+
+    return cookies.map(cookie => cookie.split(';')[0]).join('; ');
+};
+
+const createIntegration = async (sessionCookie) => {
+    const response = await request('POST', '/ghost/api/admin/integrations/?include=api_keys', {
+        body: {integrations: [{name: 'Zapier E2E'}]},
+        headers: {Cookie: sessionCookie}
+    });
+    assertStatus('Integration creation', response, 201);
+
+    const [integration] = response.json.integrations;
+    const adminKey = integration.api_keys.find(key => key.type === 'admin');
+    if (!adminKey) {
+        throw new Error('Integration creation did not return an admin API key');
+    }
+
+    // Ghost 5 returns admin key secrets already in `id:secret` form, older
+    // versions return the secret on its own
+    return adminKey.secret.includes(':') ? adminKey.secret : `${adminKey.id}:${adminKey.secret}`;
+};
+
+const exportCredentials = (adminApiKey) => {
+    const lines = [
+        `GHOST_ADMIN_API_URL=${GHOST_URL}`,
+        `GHOST_ADMIN_API_KEY=${adminApiKey}`
+    ];
+
+    if (process.env.GITHUB_ENV) {
+        fs.appendFileSync(process.env.GITHUB_ENV, `${lines.join('\n')}\n`);
+        console.log(`Ghost Admin API credentials appended to ${process.env.GITHUB_ENV}`);
+    } else {
+        console.log(lines.join('\n'));
+    }
+};
+
+const bootstrap = async () => {
+    await createOwner();
+    const sessionCookie = await createSession();
+    const adminApiKey = await createIntegration(sessionCookie);
+    exportCredentials(adminApiKey);
+};
+
+// guard so that mocha (or anything else) can require this file without
+// triggering the setup flow
+if (require.main === module) {
+    bootstrap().catch((err) => {
+        console.error(err.message);
+        process.exit(1);
+    });
+}
+
+module.exports = {
+    bootstrap,
+    OWNER
+};

--- a/test-e2e/setup/bootstrap.js
+++ b/test-e2e/setup/bootstrap.js
@@ -17,7 +17,8 @@
  *    `test-e2e/setup/start-ghost.sh`, or start any Ghost yourself and set
  *    GHOST_URL if it lives elsewhere
  * 2. `node test-e2e/setup/bootstrap.js`
- * 3. export the values from test-e2e/.env.local and run `yarn test:e2e`
+ * 3. `yarn test:e2e` - the suite picks the credentials up from
+ *    test-e2e/.env.local automatically (already-set env vars win)
  */
 const http = require('http');
 const fs = require('fs');

--- a/test-e2e/setup/bootstrap.js
+++ b/test-e2e/setup/bootstrap.js
@@ -8,12 +8,14 @@
  *
  * The resulting `GHOST_ADMIN_API_URL` and `GHOST_ADMIN_API_KEY` values are
  * appended to `$GITHUB_ENV` when running in GitHub Actions, otherwise they
- * are printed to stdout for local use.
+ * are written to `test-e2e/.env.local` (gitignored) so the key never
+ * appears in logs.
  *
  * Usage: node test-e2e/setup/bootstrap.js
  */
 const http = require('http');
 const fs = require('fs');
+const {join} = require('path');
 
 const GHOST_URL = process.env.GHOST_URL || 'http://localhost:2368';
 
@@ -119,11 +121,14 @@ const exportCredentials = (adminApiKey) => {
         `GHOST_ADMIN_API_KEY=${adminApiKey}`
     ];
 
+    // never print the key itself - it would end up in CI or terminal logs
     if (process.env.GITHUB_ENV) {
         fs.appendFileSync(process.env.GITHUB_ENV, `${lines.join('\n')}\n`);
         console.log(`Ghost Admin API credentials appended to ${process.env.GITHUB_ENV}`);
     } else {
-        console.log(lines.join('\n'));
+        const envFile = join(__dirname, '..', '.env.local');
+        fs.writeFileSync(envFile, `${lines.join('\n')}\n`);
+        console.log(`Ghost Admin API credentials written to ${envFile}`);
     }
 };
 

--- a/test-e2e/setup/bootstrap.js
+++ b/test-e2e/setup/bootstrap.js
@@ -11,7 +11,13 @@
  * are written to `test-e2e/.env.local` (gitignored) so the key never
  * appears in logs.
  *
- * Usage: node test-e2e/setup/bootstrap.js
+ * Running the e2e suite locally:
+ * 1. boot a fresh Ghost on http://localhost:2368 - either point
+ *    GHOST_CORE_PATH at a TryGhost/Ghost checkout and run
+ *    `test-e2e/setup/start-ghost.sh`, or start any Ghost yourself and set
+ *    GHOST_URL if it lives elsewhere
+ * 2. `node test-e2e/setup/bootstrap.js`
+ * 3. export the values from test-e2e/.env.local and run `yarn test:e2e`
  */
 const http = require('http');
 const fs = require('fs');
@@ -62,6 +68,11 @@ const request = (method, path, {body, headers = {}} = {}) => {
 
         req.on('error', reject);
 
+        // fail fast on a hung Ghost instead of eating the job timeout
+        req.setTimeout(15000, () => {
+            req.destroy(new Error(`${method} ${path} timed out after 15s`));
+        });
+
         if (payload) {
             req.write(payload);
         }
@@ -110,7 +121,7 @@ const createIntegration = async (sessionCookie) => {
         throw new Error('Integration creation did not return an admin API key');
     }
 
-    // Ghost 5 returns admin key secrets already in `id:secret` form, older
+    // Ghost 5+ returns admin key secrets already in `id:secret` form, older
     // versions return the secret on its own
     return adminKey.secret.includes(':') ? adminKey.secret : `${adminKey.id}:${adminKey.secret}`;
 };

--- a/test-e2e/setup/start-ghost.sh
+++ b/test-e2e/setup/start-ghost.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Boots Ghost from a source checkout (TryGhost/Ghost) for the e2e suite and
+# waits until the Admin API answers on http://localhost:2368.
+#
+#   GHOST_CORE_PATH  path to a Ghost checkout or its ghost/core directory
+#                    (default: ./Ghost - the knex-migrator convention)
+#   GHOST_LOG_FILE   Ghost boot/output log (default: ./ghost-boot.log)
+#
+# Dependencies must already be installed in the checkout:
+#   pnpm install --frozen-lockfile --filter ghost...
+#
+# The database is redirected to a throwaway sqlite file so every run starts
+# from a fresh install (the e2e suite requires one) and a local checkout's
+# development database is never touched. The Ghost process keeps running in
+# the background; the PID is written to ghost.pid next to the log file.
+
+GHOST_CORE_PATH="${GHOST_CORE_PATH:-./Ghost}"
+GHOST_LOG_FILE="${GHOST_LOG_FILE:-./ghost-boot.log}"
+
+if [ -f "${GHOST_CORE_PATH}/ghost/core/index.js" ]; then
+    core_dir="${GHOST_CORE_PATH}/ghost/core"
+elif [ -f "${GHOST_CORE_PATH}/index.js" ]; then
+    core_dir="${GHOST_CORE_PATH}"
+else
+    echo "GHOST_CORE_PATH ('${GHOST_CORE_PATH}') is not a Ghost checkout - expected ghost/core/index.js" >&2
+    exit 1
+fi
+
+log_file="$(cd "$(dirname "${GHOST_LOG_FILE}")" && pwd)/$(basename "${GHOST_LOG_FILE}")"
+pid_file="$(dirname "${log_file}")/ghost.pid"
+db_file="$(mktemp -d)/ghost-e2e.db"
+
+echo "Booting Ghost from ${core_dir}"
+echo "  log: ${log_file}"
+echo "  db:  ${db_file}"
+
+(
+    cd "${core_dir}"
+    # same boot command as ghost/core's own dev tooling (see nodemon.json);
+    # env overrides force a fresh sqlite db and the url the specs expect
+    NODE_ENV=development \
+    url="http://localhost:2368" \
+    database__client="better-sqlite3" \
+    database__connection__filename="${db_file}" \
+        nohup node --conditions=source --import=tsx index.js > "${log_file}" 2>&1 &
+    echo $! > "${pid_file}"
+)
+
+echo "Ghost started with PID $(cat "${pid_file}") - stop it with: kill \$(cat ${pid_file})"
+
+for _ in $(seq 1 90); do
+    if curl -sf -o /dev/null http://localhost:2368/ghost/api/admin/site/; then
+        echo "Ghost is ready"
+        exit 0
+    fi
+    sleep 2
+done
+
+echo "Ghost did not become ready within 180s" >&2
+tail -50 "${log_file}" >&2
+exit 1

--- a/test-e2e/setup/start-ghost.sh
+++ b/test-e2e/setup/start-ghost.sh
@@ -50,6 +50,18 @@ echo "  db:  ${db_file}"
 
 echo "Ghost started with PID $(cat "${pid_file}") - stop it with: kill \$(cat ${pid_file})"
 
+# on failure or interrupt, don't leave an orphaned Ghost or temp db behind -
+# deliberately NOT on EXIT: a successful start must leave Ghost running for
+# the bootstrap and test steps that follow
+cleanup() {
+    if [ -f "${pid_file}" ]; then
+        kill "$(cat "${pid_file}")" 2>/dev/null || true
+        rm -f "${pid_file}"
+    fi
+    rm -rf "$(dirname "${db_file}")"
+}
+trap cleanup INT TERM
+
 for _ in $(seq 1 90); do
     if curl -sf -o /dev/null http://localhost:2368/ghost/api/admin/site/; then
         echo "Ghost is ready"
@@ -60,4 +72,5 @@ done
 
 echo "Ghost did not become ready within 180s" >&2
 tail -50 "${log_file}" >&2
+cleanup
 exit 1

--- a/test-e2e/setup/start-ghost.sh
+++ b/test-e2e/setup/start-ghost.sh
@@ -2,22 +2,26 @@
 set -euo pipefail
 
 # Boots Ghost from a source checkout (TryGhost/Ghost) for the e2e suite and
-# waits until the Admin API answers on http://localhost:2368.
+# waits until the Admin API answers on http://localhost:${GHOST_PORT}.
 #
 #   GHOST_CORE_PATH  path to a Ghost checkout or its ghost/core directory
 #                    (default: ./Ghost - the knex-migrator convention)
 #   GHOST_LOG_FILE   Ghost boot/output log (default: ./ghost-boot.log)
+#   GHOST_PORT       port to serve on (default: 2368)
 #
 # Dependencies must already be installed in the checkout:
 #   pnpm install --frozen-lockfile --filter ghost...
 #
-# The database is redirected to a throwaway sqlite file so every run starts
-# from a fresh install (the e2e suite requires one) and a local checkout's
-# development database is never touched. The Ghost process keeps running in
-# the background; the PID is written to ghost.pid next to the log file.
+# The database is redirected to a throwaway sqlite file next to the log so
+# every run starts from a fresh install (the e2e suite requires one), a
+# local checkout's development database is never touched, and a caller that
+# owns the log directory (e.g. test-e2e/run.sh) can clean everything up.
+# The Ghost process keeps running in the background; the PID is written to
+# ghost.pid next to the log file.
 
 GHOST_CORE_PATH="${GHOST_CORE_PATH:-./Ghost}"
 GHOST_LOG_FILE="${GHOST_LOG_FILE:-./ghost-boot.log}"
+GHOST_PORT="${GHOST_PORT:-2368}"
 
 if [ -f "${GHOST_CORE_PATH}/ghost/core/index.js" ]; then
     core_dir="${GHOST_CORE_PATH}/ghost/core"
@@ -30,7 +34,7 @@ fi
 
 log_file="$(cd "$(dirname "${GHOST_LOG_FILE}")" && pwd)/$(basename "${GHOST_LOG_FILE}")"
 pid_file="$(dirname "${log_file}")/ghost.pid"
-db_file="$(mktemp -d)/ghost-e2e.db"
+db_file="$(dirname "${log_file}")/ghost-e2e.db"
 
 echo "Booting Ghost from ${core_dir}"
 echo "  log: ${log_file}"
@@ -41,7 +45,8 @@ echo "  db:  ${db_file}"
     # same boot command as ghost/core's own dev tooling (see nodemon.json);
     # env overrides force a fresh sqlite db and the url the specs expect
     NODE_ENV=development \
-    url="http://localhost:2368" \
+    url="http://localhost:${GHOST_PORT}" \
+    server__port="${GHOST_PORT}" \
     database__client="better-sqlite3" \
     database__connection__filename="${db_file}" \
         nohup node --conditions=source --import=tsx index.js > "${log_file}" 2>&1 &
@@ -58,12 +63,13 @@ cleanup() {
         kill "$(cat "${pid_file}")" 2>/dev/null || true
         rm -f "${pid_file}"
     fi
-    rm -rf "$(dirname "${db_file}")"
+    # keep the log around for inspection, only remove the throwaway db
+    rm -f "${db_file}"
 }
 trap cleanup INT TERM
 
 for _ in $(seq 1 90); do
-    if curl -sf -o /dev/null http://localhost:2368/ghost/api/admin/site/; then
+    if curl -sf -o /dev/null "http://localhost:${GHOST_PORT}/ghost/api/admin/site/"; then
         echo "Ghost is ready"
         exit 0
     fi


### PR DESCRIPTION
ref [GVA-831](https://linear.app/ghost/issue/GVA-831/clean-repos-zapier)

PR 3 of the CI-trust remediation stack (base: `gva-831/2-unit-tests-coverage-gate`, PR #93). The unit suite mocks every Ghost response with nock, so it can never catch Ghost-side contract drift. This PR adds an e2e layer that runs the same Zapier operations against a real Ghost instance, and the `Required checks pass` aggregator job that branch protection will require.

## E2E design

- **CI boots Ghost from source** — TryGhost/Ghost `main` (currently 6.50.0-rc.0), not a released docker image. Owner decision: the required check exercises the app against Ghost's current development head for maximum boundary realism, explicitly accepting the upstream-churn trade-off (a breaking change on Ghost main can redden this gate before any Ghost release ships it).
- The job checks out TryGhost/Ghost with submodules (the default theme is one), installs with corepack-pinned pnpm + cached store (`pnpm install --frozen-lockfile --filter ghost...`, modeled on knex-migrator's `ghost-consumer-smoke`), and boots `ghost/core` with the same command Ghost's own dev tooling uses: `NODE_ENV=development node --conditions=source --import=tsx index.js` (sqlite, no built admin assets needed — the Admin API serves without them). Node 22.18.0 per Ghost's `engines`; the Zapier app keeps its own 14/20/22/24 matrix in the build job.
- **`test-e2e/setup/start-ghost.sh`** owns boot + readiness (bounded poll of `/ghost/api/admin/site/`) and honours `GHOST_CORE_PATH` (knex-migrator convention) for local runs. It redirects the database to a throwaway sqlite file so every run is the fresh install the suite requires and a local checkout's dev database is never touched.
- **`test-e2e/setup/bootstrap.js`** provisions the fresh install over plain HTTP using Ghost's own setup flow — `POST /authentication/setup/` (owner), `POST /session/` (cookie), `POST /integrations/?include=api_keys` (custom "Zapier E2E" integration) — and exports `GHOST_ADMIN_API_URL` / `GHOST_ADMIN_API_KEY` to `$GITHUB_ENV` (gitignored `test-e2e/.env.local` locally). No new dependencies; core `http` only, with a 15s request timeout so a hung Ghost fails fast.
- **`test-e2e/` specs** reuse the exact same `appTester` entry points as the unit tests, but with real authData and no nock. They live outside `test/` and outside c8, so the unit run and its 80% coverage gate are untouched (`test` script unchanged; new `test:e2e` script). Specs fail fast with a setup hint when the env vars are missing.
- Numbered file prefixes make mocha's alphabetical load order explicit: creates seed the member/posts/tag that the search and trigger specs then assert on, mirroring how data flows through a real Zap.

## Operation coverage matrix

| Operation | Real Ghost e2e | Notes |
| --- | --- | --- |
| `authentication.test` | ✅ success + wrong-key failure | returns real blogTitle/blogUrl; wrong key asserted on Ghost's "Invalid token" rejection |
| `create_member` | ✅ | `send_email: false` (no mail transport in CI) |
| `update_member` | ✅ | incl. `newsletters` against the default newsletter |
| `create_post` | ✅ | html source; published post + `scheduled` post with future `published_at`; seeds a new tag |
| `member` search | ✅ hit + miss→`[]` | |
| `author` search | ✅ by email and slug, hit + miss | owner slug resolved dynamically |
| performList: `post_published`, `post_scheduled`, `page_published`, `member_created`, `member_updated`, `member_deleted`, `newsletter_created`, `tag_created`, `author_created` | ✅ | seeded via creates; `page_published` uses the fixture "About this site" page; `member_updated` asserts the static sample after the real version check |
| webhook subscribe/unsubscribe | ✅ round-trip for all 9 modern hook triggers | asserts returned webhook id, then DELETE succeeds |
| `create_subscriber`, `delete_subscriber`, `subscriber` search, `subscriber_created`/`subscriber_deleted` performList + performSubscribe/performUnsubscribe | ✅ (as version-gate) | subscribers API was **removed in Ghost 3.0** — the correct real behaviour on modern Ghost is the `HaltedError` "does not support subscribers", and that is what the specs assert |
| v0.1 auth fallback (`/ghost/api/v0.1/configuration/about/`) | ❌ nock-only | no bootable Ghost 0.x exists to run against; unit tests keep covering this branch |
| Subscriber happy paths (create/find/delete on Ghost <3.0) | ❌ nock-only | same reason — Ghost 1.x/2.x are not practically bootable/supported in CI |

Verified against Ghost main: legacy `/v2|v3|v4/` API paths are still rewritten (`ghost/core/core/server/services/api-version-compatibility/legacy-api-path-match.js`), so the SDK's v2/v3 URLs keep working; all 36 specs passed against 6.50.0-rc.0 with **zero assertion changes** (default newsletter, About page, `id:secret` admin keys, and the subscriber version-gate all hold on main).

## Workflow

- `E2E (real Ghost)` job: ubuntu-latest, `timeout-minutes: 30`, SHA-pinned checkout/setup-node/cache, `persist-credentials: false` on all checkouts, pnpm store cache keyed on Ghost's lockfile, readiness poll bounded at ~180s, Ghost boot log dumped on failure.
- `Required checks pass` aggregator (`needs: [build, e2e]`, `if: always()`, fails on `failure`/`cancelled`/`skipped`): the single stable required check, decoupled from matrix leg names.
- Top-level `permissions: contents: read`.

## Local run

`yarn test:e2e` is self-contained (`test-e2e/run.sh`). Resolution order:

1. `GHOST_ADMIN_API_URL`/`GHOST_ADMIN_API_KEY` exported (the CI path): runs mocha directly, no lifecycle management.
2. A `test-e2e/.env.local` whose Ghost still answers: reused. Stale files (dead Ghost) are detected with a probe and re-provisioned.
3. `GHOST_CORE_PATH=/path/to/Ghost`: boots Ghost from that source checkout (deps installed).
4. Docker available: boots a throwaway `ghost:6` container in development mode (development so sqlite works — verified against 6.49, 36/36 passing; no MySQL service needed).
5. Otherwise: fails with the three options above.

Self-provisioned Ghosts are always fresh installs (the fixtures use fixed emails/titles) on a free port (preferring 2368, so it works next to a running Ghost dev stack) and are torn down afterwards — pass or fail — with mocha's exit code preserved. `yarn test:e2e:bare` remains the raw mocha run for CI or an already-provisioned instance.

## Commands run

- `yarn lint` ✅
- `yarn test` ✅ 140 passing, coverage gate intact (unit suite untouched)
- Local real e2e, exactly as CI does it: fresh clone of TryGhost/Ghost main + `pnpm install --frozen-lockfile --filter ghost...` → `start-ghost.sh` → `bootstrap.js` → `yarn test:e2e` ✅ **36 passing** against Ghost 6.50.0-rc.0
- Fail-fast check: `yarn test:e2e` without env vars fails immediately with a clear setup hint

CI evidence: see the `E2E (real Ghost)` and `Required checks pass` checks on this PR (the workflow change is in this branch).

