### PR TITLE
Switch Renovate to the shared TryGhost preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,0 @@
-{
-  "extends": [
-    "config:base"
-  ]
-}

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,19 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    extends: [
+        'local>TryGhost/renovate-config',
+    ],
+    packageRules: [
+        {
+            description: 'Keep zapier-platform-core below v15: the app is deployed on the Zapier Node 14 Lambda runtime with core 12, and core v15+ requires Node 16+. Platform-core majors also change the deployed Zapier runtime and need a coordinated `zapier push`/promote, so they must never ride an automated Renovate merge. Revisit with the planned manual core 12 -> 19 upgrade.',
+            matchPackageNames: ['zapier-platform-core'],
+            allowedVersions: '<15',
+        },
+        {
+            description: "Keep the e2e job's setup-node on Node 22: it boots Ghost from source and follows Ghost's engines (^22.18.0). The shared preset automerges uses-with bumps, so without this rule a major bump to Node 24 would silently drift e2e off Ghost's supported runtime. Patch/minor bumps within 22 stay in range and may automerge.",
+            matchManagers: ['github-actions'],
+            matchPackageNames: ['node'],
+            allowedVersions: '<23',
+        },
+    ],
+}


### PR DESCRIPTION
This standardizes the repo's Renovate setup on the shared TryGhost config, part of the org-wide effort to keep dependency-update policy consistent across repos.

## What changed

| | Before | After |
|---|---|---|
| File | `renovate.json` | `renovate.json5` (JSON5 so rules can carry commented rationale) |
| Preset | `config:base` | `local>TryGhost/renovate-config` |
| Local rules | none | 2 runtime-compatibility `packageRules` (below) |

No `package.json` `renovate` key existed, and the old config had no local overrides — it was only `{"extends": ["config:base"]}` — so nothing was dropped or migrated beyond the preset swap.

## Preset decision

The `resolve_preset.py` helper output with repo-meta trust (`ci_trust: medium`, stale):

```
repo: Zapier
slug: zapier
type: package
ci_trust: medium
ci_trust_source: repo-meta
risk: high
expected_preset: safe
preset_ref: local>TryGhost/renovate-config:safe
```

Repo-meta predates the CI-trust remediation work, so per the skill the helper was rerun with the live-verified trust level:

```
repo: Zapier
slug: zapier
type: package
ci_trust: high
ci_trust_source: live-verification
repo_meta_ci_trust: medium
risk: high
expected_preset: default
preset_ref: local>TryGhost/renovate-config
recommended_new_file: renovate.json5
```

Live verification evidence (current `main`):

- c8 coverage gate 80/80/80/80 enforced in `yarn test` on all four Node matrix legs (14/20/22/24); actual coverage is 100%.
- 36 e2e tests boot Ghost from source (TryGhost/Ghost `main`) and exercise every trigger/create/search, including webhook round-trips.
- Renovate PRs run the full suite on the `pull_request` event with no skip conditions.
- The `Required checks pass` aggregator (fails on failure/cancelled/skipped) is enforced by an active repository ruleset on `main` (id 18429435) with strict up-to-date policy.
- A breaking dependency update would therefore fail PR CI, which is the high-trust gate for the full (automerging) preset — the same one TryGhost/Octo and TryGhost/Velo use.

## Local packageRules

1. **`zapier-platform-core` capped at `<15`.** The app runs on the Zapier Node 14 Lambda runtime with core 12; core v15+ requires Node 16+. Platform-core majors also change the deployed Zapier Lambda runtime and need a coordinated `zapier push`/promote, so they must never ride an automated Renovate merge. A core 12→19 upgrade is planned as a separate manual PR later in this cleanup, at which point this guard gets revisited.
2. **github-actions `node` capped at `<23`.** The e2e job pins `setup-node` to `22.18.0`, deliberately following Ghost's `engines` (`^22.18.0`) because it boots Ghost from source. The shared preset automerges the `uses-with` depType (majors included), so without this rule a bump to Node 24 would automerge and silently drift e2e off Ghost's supported runtime. Patch/minor bumps within Node 22 stay inside Ghost's range and may automerge. The cap is `<23` rather than an exact pin because the workflow's intent is a range floor, not a frozen patch; the repo's own runtime legs (`14/20/22/24` build matrix) are `${{ matrix.node }}` templates Renovate does not manage, so nothing else is constrained.

The repo does not depend on `jsonwebtoken`, so the org-standard `<9` guard is not needed here.

## Verification

- `renovate-config-validator --strict` on `renovate.json5`: `INFO: Config validated successfully` (no strict-mode warnings).
- `yarn lint`: pass.
- `yarn test`: pass, coverage 100% across all files.

ref [GVA-831](https://linear.app/ghost/issue/GVA-831/clean-repos-zapier)