### PR TITLE
Declare lodash as a direct dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@tryghost/admin-api": "1.13.0",
+    "lodash": "4.17.21",
     "semver": "7.5.2",
     "zapier-platform-core": "12.0.3"
   },


### PR DESCRIPTION
## Why

A Knip dependency scan (`npx knip --dependencies`, yarn classic) for the Clean Repos run found **zero unused dependencies** — all 3 runtime deps and 5 devDeps are in use — but flagged `lodash` as **unlisted**: it is required by five trigger modules (`app/triggers/{post_published,post_scheduled,page_published,tag_created,author_created}.js`) while only being hoisted transitively from `zapier-platform-core` (verified with `yarn why lodash`).

A phantom dependency like this breaks silently when the parent package drops or bumps it — exactly the failure mode CI-gated automated dependency updates are meant to catch. Declaring it makes Renovate manage it directly.

## What

- Add `lodash: 4.17.21` to `dependencies` (exact pin, matching the resolved version and the repo's existing pin style). `yarn.lock` unchanged apart from the direct-dependency marker (`Saved 0 new dependencies` — same resolved version).

## Retained findings

None — after this change `npx knip --dependencies` reports a fully clean state.

## Verification

- `npx knip --dependencies` → clean
- `yarn --frozen-lockfile` install check, `yarn lint` clean, `yarn test` 140 passing with the coverage gate
- No package-manager migration, CI, Renovate, or lint changes included

ref [GVA-831](https://linear.app/ghost/issue/GVA-831/clean-repos-zapier)