### PR TITLE
Fix tag_created webhook reading wrong payload key

### DIFF
--- a/app/triggers/tag_created.js
+++ b/app/triggers/tag_created.js
@@ -5,14 +5,14 @@ const webhooks = require('../lib/webhooks');
 const subscribeWebhook = _.partial(webhooks.subscribe, 'tag.added');
 const unsubscribeWebhook = webhooks.unsubscribe;
 
-// triggers on user.added. Formats the API response ready for passing to
+// triggers on tag.added. Formats the API response ready for passing to
 // the zap which expects an array
 const handleWebhook = (z, bundle) => {
     // bundle.cleanedRequest will include the parsed JSON object (if it's not a
     // test poll) and also a .querystring property with the URL's query string.
-    const {user} = bundle.cleanedRequest;
+    const {tag} = bundle.cleanedRequest;
 
-    return [user.current];
+    return [tag.current];
 };
 
 const listTags = (z, {authData, meta}) => {
@@ -38,7 +38,7 @@ module.exports = {
     display: {
         label: 'Tag Created',
         description: 'Triggers when a new tag is added.',
-        hidden: true // only used by authors dynamic dropdown
+        hidden: true // only used by tags dynamic dropdown
     },
 
     operation: {

--- a/test/triggers/tag_created.test.js
+++ b/test/triggers/tag_created.test.js
@@ -42,12 +42,10 @@ describe('Triggers', function () {
         });
 
         it('loads tag from webhook data', function () {
-            // app code reads `user` here — copy-paste from author_created;
-            // this test documents current behaviour (see PR #93)
             let bundle = Object.assign({}, {authData}, {
                 inputData: {},
                 cleanedRequest: {
-                    user: {
+                    tag: {
                         current: sampleTag,
                         previous: {}
                     }


### PR DESCRIPTION
## Bug

`app/triggers/tag_created.js`'s webhook `perform` read `bundle.cleanedRequest.user` — copy-pasted from `author_created` — and returned `user.current`. Ghost sends `tag.added` webhook payloads under a `tag` key, so a real webhook delivery would throw `TypeError: Cannot read properties of undefined`.

## Evidence

Ghost's `tag.added` webhook payload shape is:

```json
{
    "tag": {
        "current": {"id": "...", "name": "...", "slug": "..."},
        "previous": {}
    }
}
```

i.e. the resource key matches the webhook resource, exactly as `post_published` reads `cleanedRequest.post` and `author_created` (subscribed to `user.added`, where the resource is a user) reads `cleanedRequest.user`.

The bug was found and documented during the test-coverage work in #93, where fixing it was deliberately deferred to keep that PR test-only.

## Impact

Low risk: the trigger is `hidden: true` (only used to fill the tags dynamic dropdown via `performList`), so the `perform` path is unreachable in production Zaps today. This is correctness hygiene so the handler works if the trigger is ever exposed.

## Changes

- `perform` now destructures `tag` from `bundle.cleanedRequest` and returns `[tag.current]`, mirroring `post_published`/`author_created`
- Fixed stale copy-pasted comments (`user.added` → `tag.added`, "authors dynamic dropdown" → "tags dynamic dropdown")
- The "loads tag from webhook data" test now asserts the correct payload shape (`cleanedRequest.tag.current`) instead of documenting the buggy behaviour; the bug-documenting comment is removed

## Verification

- `yarn lint` clean
- `yarn test`: 140 passing, coverage gate intact (`tag_created.js` at 100%)

ref [GVA-831](https://linear.app/ghost/issue/GVA-831/clean-repos-zapier)