### PR TITLE
Polish the member actions' ID field help and sample data

### DIFF
--- a/app/creates/create_member.js
+++ b/app/creates/create_member.js
@@ -148,11 +148,31 @@ module.exports = {
 
         sample: {
             id: '5c9c9c8d51b5bf974afad2a4',
-            name: 'Test Member',
+            uuid: '0f5b95a5-a08b-4e29-b0a0-8dcbc4b7e83f',
             email: 'test@example.com',
+            name: 'Test Member',
+            note: 'Just a sample member record.',
             subscribed: true,
+            status: 'free',
             comped: false,
-            labels: ['Zapier'],
+            avatar_image: 'https://www.gravatar.com/avatar/00000000000000000000000000000000?s=250&r=g&d=blank',
+            labels: [
+                {
+                    id: '5f212d395422021ebc4b7043',
+                    name: 'Zapier',
+                    slug: 'zapier',
+                    created_at: '2019-03-28T10:06:05.862Z',
+                    updated_at: '2019-03-28T10:06:05.862Z'
+                }
+            ],
+            newsletters: [
+                {
+                    id: '62e12664bbd0f0cb56f6f7d1',
+                    name: 'Sample Newsletter',
+                    description: null,
+                    status: 'active'
+                }
+            ],
             created_at: '2019-03-28T10:06:05.862Z',
             updated_at: '2019-03-28T10:06:05.862Z'
         }

--- a/app/creates/update_member.js
+++ b/app/creates/update_member.js
@@ -53,6 +53,7 @@ module.exports = {
                 key: 'id',
                 required: true,
                 label: 'Member',
+                helpText: 'Select the member to update, or map the Member ID from a previous step. Note this must be a Member ID, not a Label ID.',
                 dynamic: 'member_created.id.name',
                 search: 'member.id'
             },

--- a/app/creates/update_member.js
+++ b/app/creates/update_member.js
@@ -127,11 +127,31 @@ module.exports = {
 
         sample: {
             id: '5c9c9c8d51b5bf974afad2a4',
-            name: 'Test Member',
+            uuid: '0f5b95a5-a08b-4e29-b0a0-8dcbc4b7e83f',
             email: 'test@example.com',
-            comped: false,
+            name: 'Test Member',
+            note: 'Just a sample member record.',
             subscribed: true,
-            labels: ['Zapier'],
+            status: 'free',
+            comped: false,
+            avatar_image: 'https://www.gravatar.com/avatar/00000000000000000000000000000000?s=250&r=g&d=blank',
+            labels: [
+                {
+                    id: '5f212d395422021ebc4b7043',
+                    name: 'Zapier',
+                    slug: 'zapier',
+                    created_at: '2019-03-28T10:06:05.862Z',
+                    updated_at: '2019-03-28T10:06:05.862Z'
+                }
+            ],
+            newsletters: [
+                {
+                    id: '62e12664bbd0f0cb56f6f7d1',
+                    name: 'Sample Newsletter',
+                    description: null,
+                    status: 'active'
+                }
+            ],
             created_at: '2019-03-28T10:06:05.862Z',
             updated_at: '2019-03-28T10:06:05.862Z'
         }

--- a/app/searches/member.js
+++ b/app/searches/member.js
@@ -45,17 +45,29 @@ module.exports = {
 
         sample: {
             id: '5a01d3ecc8d50d0e606a7e7c',
-            name: 'Sample Member',
+            uuid: '42f50516-9d4f-4062-86fe-dc170d2b391c',
             email: 'sample@example.com',
+            name: 'Sample Member',
             note: 'Just a sample member record.',
             subscribed: true,
+            status: 'free',
             comped: false,
+            avatar_image: 'https://www.gravatar.com/avatar/00000000000000000000000000000000?s=250&r=g&d=blank',
             labels: [
                 {
+                    id: '5f212d395422021ebc4b7043',
                     name: 'Zapier',
                     slug: 'zapier',
                     created_at: '2019-10-13T18:12:00.000Z',
                     updated_at: '2019-10-13T18:12:00.000Z'
+                }
+            ],
+            newsletters: [
+                {
+                    id: '62e12664bbd0f0cb56f6f7d1',
+                    name: 'Sample Newsletter',
+                    description: null,
+                    status: 'active'
                 }
             ],
             created_at: '2019-10-13T18:12:00.000Z',

--- a/app/triggers/member_created.js
+++ b/app/triggers/member_created.js
@@ -53,15 +53,29 @@ module.exports = {
 
         sample: {
             id: '5a01d3ecc8d50d0e606a7e7c',
-            name: 'Sample Member',
+            uuid: '42f50516-9d4f-4062-86fe-dc170d2b391c',
             email: 'sample@example.com',
+            name: 'Sample Member',
             note: 'Just a sample member record.',
+            subscribed: true,
+            status: 'free',
+            comped: false,
+            avatar_image: 'https://www.gravatar.com/avatar/00000000000000000000000000000000?s=250&r=g&d=blank',
             labels: [
                 {
+                    id: '5f212d395422021ebc4b7043',
                     name: 'Zapier',
                     slug: 'zapier',
                     created_at: '2019-10-13T18:12:00.000Z',
                     updated_at: '2019-10-13T18:12:00.000Z'
+                }
+            ],
+            newsletters: [
+                {
+                    id: '62e12664bbd0f0cb56f6f7d1',
+                    name: 'Sample Newsletter',
+                    description: null,
+                    status: 'active'
                 }
             ],
             created_at: '2019-10-13T18:12:00.000Z',

--- a/app/triggers/member_deleted.js
+++ b/app/triggers/member_deleted.js
@@ -49,11 +49,32 @@ module.exports = {
         perform: handleWebhook,
         performList: getLatestMember,
 
+        // matches the `member.previous` webhook payload, which omits the
+        // subscription flags included by other member events
         sample: {
             id: '5a01d3ecc8d50d0e606a7e7c',
-            name: 'Sample Member',
+            uuid: '42f50516-9d4f-4062-86fe-dc170d2b391c',
             email: 'sample@example.com',
+            name: 'Sample Member',
             note: 'Just a sample member record.',
+            status: 'free',
+            labels: [
+                {
+                    id: '5f212d395422021ebc4b7043',
+                    name: 'Zapier',
+                    slug: 'zapier',
+                    created_at: '2019-10-13T18:12:00.000Z',
+                    updated_at: '2019-10-13T18:12:00.000Z'
+                }
+            ],
+            newsletters: [
+                {
+                    id: '62e12664bbd0f0cb56f6f7d1',
+                    name: 'Sample Newsletter',
+                    description: null,
+                    status: 'active'
+                }
+            ],
             created_at: '2019-10-13T18:12:00.000Z',
             updated_at: '2019-10-13T18:12:00.000Z'
         }

--- a/app/triggers/member_updated.js
+++ b/app/triggers/member_updated.js
@@ -6,12 +6,13 @@ const SAMPLE_PAYLOAD = {
     current: {
         id: '5a01d3ecc8d50d0e606a7e7c',
         uuid: '42f50516-9d4f-4062-86fe-dc170d2b391c',
-        name: 'New Member Name',
         email: 'sample@example.com',
+        name: 'New Member Name',
         note: 'Updated sample member record.',
         subscribed: false,
         status: 'paid',
         comped: true,
+        avatar_image: 'https://www.gravatar.com/avatar/00000000000000000000000000000000?s=250&r=g&d=blank',
         labels: [{
             id: '5f212d395422021ebc4b7043',
             name: 'Old label 1',
@@ -19,15 +20,23 @@ const SAMPLE_PAYLOAD = {
             created_at: '2020-10-13T18:12:00.000Z',
             updated_at: '2020-10-13T18:12:00.000Z'
         }, {
-            id: '5f212d395422021ebc4b7043',
+            id: '5f212d395422021ebc4b7044',
             name: 'New label',
             slug: 'new-label',
             created_at: '2020-10-13T18:12:00.000Z',
             updated_at: '2020-10-13T18:12:00.000Z'
         }],
+        newsletters: [{
+            id: '62e12664bbd0f0cb56f6f7d1',
+            name: 'Sample Newsletter',
+            description: null,
+            status: 'active'
+        }],
         created_at: '2019-10-13T18:12:00.000Z',
         updated_at: '2019-10-31T19:58:00.000Z'
     },
+    // the real webhook's `previous` object only contains the attributes
+    // that changed with this edit
     previous: {
         name: 'Old Member Name',
         email: 'oldsample@example.com',
@@ -42,9 +51,9 @@ const SAMPLE_PAYLOAD = {
             created_at: '2020-10-13T18:12:00.000Z',
             updated_at: '2020-10-13T18:12:00.000Z'
         }, {
-            id: '5f212d395422021ebc4b7043',
+            id: '5f212d395422021ebc4b7045',
             name: 'Old label 2',
-            slug: 'old-label 2',
+            slug: 'old-label-2',
             created_at: '2020-10-13T18:12:00.000Z',
             updated_at: '2020-10-13T18:12:00.000Z'
         }],

--- a/test/triggers/member_updated.test.js
+++ b/test/triggers/member_updated.test.js
@@ -62,7 +62,7 @@ describe('Triggers', function () {
             return appTester(App.triggers.member_updated.operation.performList, {authData})
                 .then(([member]) => {
                     expect(member.current).toBeTruthy();
-                    expect(Object.keys(member.current).length).toEqual(11);
+                    expect(Object.keys(member.current).length).toEqual(13);
                     expect(member.previous).toBeTruthy();
                     expect(Object.keys(member.previous).length).toEqual(8);
 


### PR DESCRIPTION
Two small polish changes for the member actions.

## 1. Help text for the Update Member "Member" field

Closes #44

The dynamic dropdown for the required `id` field surfaces several IDs and users were picking the Label ID that sorted first, breaking their Zaps. Zap Templates also strip required-field mappings, so there was no hint which ID to map. The field now carries:

> Select the member to update, or map the Member ID from a previous step. Note this must be a Member ID, not a Label ID.

## 2. Member samples aligned with the real Ghost 6 member shape

The static `sample` blocks for `member_created`/`member_updated`/`member_deleted`, `create_member`/`update_member`, and the member search dated back to Ghost 2-era responses — no `status`, no `newsletters`, labels as plain strings in the creates, and duplicated label ids in the `member_updated` payload. These samples are what users map from when configuring a Zap before real data exists.

### Evidence

Captured from a real `ghost:6` docker container (same provisioning as the e2e stack: boot container, run `test-e2e/setup/bootstrap.js`, create a member via the Admin API, and record both the `members.browse`/`add`/`edit` responses and the actual `member.added`/`member.edited`/`member.deleted` webhook payloads).

Real Ghost 6 `member.added` webhook `member.current` (the shape `member_created`'s perform returns):

```json
{
  "id": "6a475e9a28da050001d8d0ee",
  "uuid": "e5e6d9ea-265b-4ab9-b5f8-a14baaa042ee",
  "email": "shape-probe-2@example.com",
  "name": "Shape Probe",
  "note": "Probe member for sample shape",
  "geolocation": null,
  "subscribed": true,
  "created_at": "2026-07-03T07:02:50.000Z",
  "updated_at": "2026-07-03T07:02:50.000Z",
  "labels": [
    {"id": "6a475e6c28da050001d8d0de", "name": "Zapier", "slug": "zapier", "created_at": "...", "updated_at": "..."}
  ],
  "subscriptions": [],
  "avatar_image": "https://www.gravatar.com/avatar/21e8...?s=250&r=g&d=blank",
  "comped": false,
  "email_count": 0,
  "email_opened_count": 0,
  "email_open_rate": null,
  "status": "free",
  "last_seen_at": null,
  "enable_comment_notifications": true,
  "enable_updates_and_announcements": null,
  "can_comment": true,
  "commenting": {"disabled": false, "disabled_reason": null, "disabled_until": null},
  "tiers": [],
  "current_subscription": null,
  "newsletters": [
    {"id": "6a475e1228da050001d8cdd2", "name": "Zapier E2E", "description": null, "status": "active"}
  ]
}
```

New sample (`member_created`, same shape used across the search and creates with their existing fake values):

```js
sample: {
    id: '5a01d3ecc8d50d0e606a7e7c',
    uuid: '42f50516-9d4f-4062-86fe-dc170d2b391c',
    email: 'sample@example.com',
    name: 'Sample Member',
    note: 'Just a sample member record.',
    subscribed: true,
    status: 'free',
    comped: false,
    avatar_image: 'https://www.gravatar.com/avatar/00000000000000000000000000000000?s=250&r=g&d=blank',
    labels: [{id: '5f212d395422021ebc4b7043', name: 'Zapier', slug: 'zapier', created_at: '...', updated_at: '...'}],
    newsletters: [{id: '62e12664bbd0f0cb56f6f7d1', name: 'Sample Newsletter', description: null, status: 'active'}],
    created_at: '2019-10-13T18:12:00.000Z',
    updated_at: '2019-10-13T18:12:00.000Z'
}
```

### Trimming choices

Kept everything users realistically map: `id`, `uuid`, `email`, `name`, `note`, `subscribed`, `status`, `comped`, `avatar_image`, `labels`, `newsletters`, `created_at`, `updated_at`.

Dropped from the samples to avoid bloating them with rarely-mapped noise: `geolocation`, `subscriptions`, `tiers`, `current_subscription`, `attribution`, `email_count`, `email_opened_count`, `email_open_rate`, `last_seen_at`, `enable_comment_notifications`, `enable_updates_and_announcements`, `unsubscribe_url`, `can_comment`, `commenting`, `email_suppression`.

Shape-accurate per action:

- `member_deleted` omits `subscribed`/`comped`/`avatar_image` because the real `member.deleted` webhook's `member.previous` payload does not include them (verified against the captured payload).
- `member_updated`'s `previous` keeps only changed attributes, matching the real webhook behaviour (a real edit produced `previous: {"name": "...", "updated_at": "..."}`), with a comment saying so. Also fixes the duplicated label id and the `'old-label 2'` slug typo in the old sample.
- No `perform`/`performList` logic changed; the only test change is the key-count assertion for the `member_updated` static payload (11 → 13 keys).

## Verification

- `yarn lint` clean
- `yarn test` 96/96, 100% statements/branches/functions/lines
- `yarn test:e2e` 29/29 against a fresh ghost:6 docker container
- `npx zapier-platform-cli@19 validate` 25 checks passed, 0 failed (remaining warnings pre-exist)

ref [GVA-831](https://linear.app/ghost/issue/GVA-831/clean-repos-zapier)
