### PR TITLE
Rework the repo docs after the modernization

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @royalfig

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 build
-docs
 node_modules
 *.log
 .environment

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,59 @@
+# AGENTS.md
+
+Ghost's official Zapier integration — a Zapier Platform CLI app
+(`zapier-platform-core` 19, Node 22, CommonJS). See [README.md](README.md)
+for what it does and [docs/deployment.md](docs/deployment.md) for the release
+runbook.
+
+## Commands
+
+```sh
+pnpm install
+pnpm lint       # oxlint + oxfmt --check
+pnpm lint:fix
+pnpm test       # vitest unit tests, coverage gated at 100%
+pnpm test:e2e   # self-contained: boots a throwaway ghost:6 docker container
+```
+
+`pnpm test:e2e` provisions, bootstraps, and tears down its own Ghost when
+Docker is available. Overrides: `GHOST_CORE_PATH=/path/to/Ghost` boots Ghost
+from a source checkout instead; or point it at a fresh Ghost you run yourself
+via `node test-e2e/setup/bootstrap.js` (set `GHOST_URL` if it is not on
+`http://localhost:2368`).
+
+## Boundaries
+
+- **Never run `zapier-platform push`, `promote`, or `migrate`.** Deploying to
+  Zapier is human-owned — see [docs/deployment.md](docs/deployment.md).
+- **Never bump `version` in package.json.** Versions are owner-managed as
+  part of the manual release flow.
+- **Never lower the coverage thresholds** in `vitest.config.js` — they are
+  100% across the board and gate CI.
+- **The Ghost compatibility floor is single-sourced** as `GHOST_MAJOR` in
+  `app/lib/utils.js`: the auth-time version check and the `Accept-Version`
+  request header must move together. Don't hardcode Ghost versions elsewhere.
+- **Keep the Renovate guards in `renovate.json5`.** `zapier-platform-core`
+  majors change Zapier's deployed Lambda runtime and need a coordinated
+  manual push/promote/migrate, so they must never ride an automated merge;
+  the pnpm `<11` and e2e setup-node `<23` rules protect the supported Node
+  range. Each rule's `description` explains its reasoning — update it if you
+  change the rule.
+
+## Conventions
+
+- 4-space indentation, single quotes — enforced by oxfmt; `pnpm lint` must
+  pass before committing.
+- vitest APIs are imported explicitly (`import { describe, it, expect } from
+  'vitest'`) — globals are not enabled.
+- Dependencies are pinned to exact versions; Renovate keeps them current.
+- Commit messages explain **why** the change was made, not what changed. No
+  `Co-Authored-By` trailers.
+
+## Gotchas
+
+- The e2e specs share state (02-creates seeds fixtures the later specs assert
+  on) and run one file at a time in filename order — `vitest.e2e.config.js`
+  enforces this. Don't parallelise them or renumber the files.
+- The `sample` objects in `app/` triggers/creates/searches mirror real
+  Ghost 6 API shapes and are shown to users in the Zap editor — don't trim
+  or invent fields.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/README.md
+++ b/README.md
@@ -1,86 +1,90 @@
 # Ghost-Zapier
 
-## Getting started
-The app is built using "Zapier Platform CLI". An introductory guide into building and maintaining such apps is available [here](https://platform.zapier.com/cli_tutorials/getting-started).
+The official [Ghost integration on Zapier](https://zapier.com/apps/ghost) — a
+Zapier Platform CLI app that provides Ghost triggers, creates, and searches
+backed by the Ghost Admin API.
 
-Quick command reference to get started with development:
-```
-# install the CLI globally (the binary is called `zapier-platform` since v19)
-npm install --global zapier-platform-cli
+## What it does
 
-# setup auth to Zapier's platform with a deploy key
-zapier-platform login
+Zapier users connect their Ghost site with an Admin API key and URL (from
+Ghost Admin under `Integrations » Zapier`) and build Zaps from:
 
-# setup dependencies
-pnpm install
+- **Triggers** — instant REST hooks fed by Ghost webhooks: post/page
+  published, post scheduled, member created/updated/deleted, tag, author, and
+  newsletter created
+- **Creates** — create a post, create or update a member
+- **Searches** — find a member or an author
 
-zapier-platform test
-```
-
-## Node version support
-
-This app is built on `zapier-platform-core` v19, which runs on Zapier's Node.js 22 Lambda runtime — use Node 22 locally. More details are available in the [requirements doc](https://docs.zapier.com/platform/reference/cli-docs#requirements).
-
-Notes:
-- there is a `.nvmrc` file in this project if you have `nvm` auto-switching enabled
+All requests target the unversioned Admin API (`/ghost/api/admin/`) and
+declare their compatibility version via the `Accept-Version` header.
 
 ## Ghost version support
 
-New Zap connections require **Ghost 6.0 or later**. Zapier checks the version of Ghost when authenticating by fetching the `/ghost/api/admin/site/` endpoint, and all requests declare their compatibility version via the `Accept-Version` header.
+New Zap connections require **Ghost 6.0 or later**. Authentication reads
+`/ghost/api/admin/site/` and checks the reported version against the
+supported range — single-sourced as `SUPPORTED_GHOST_VERSION` in
+[`app/lib/utils.js`](app/lib/utils.js), alongside the `Accept-Version` value.
+Review it when a new major version of Ghost is released.
 
-Sites on older Ghost versions keep working: existing Zaps stay pinned to the previously published integration versions they were created with (Zapier does not migrate Zaps across integration major versions), they just cannot connect through the current version.
+Sites on older Ghost versions keep working: existing Zaps stay pinned to the
+previously published integration versions they were created with (Zapier does
+not migrate Zaps across integration major versions) — they just cannot make
+new connections through the current version.
 
-When a new major version of Ghost is released the supported version string (`SUPPORTED_VERSION` in `app/authentication.js`) must be reviewed!
+## Getting started
+
+The app runs on `zapier-platform-core` v19, which uses Zapier's Node.js 22
+Lambda runtime — use Node 22 locally (there is a `.nvmrc` if you have `nvm`
+auto-switching enabled). See Zapier's
+[CLI requirements](https://docs.zapier.com/integrations/reference/cli-docs#requirements)
+for details.
+
+```sh
+# install the Zapier CLI globally (the binary is called `zapier-platform` since v19)
+npm install --global zapier-platform-cli
+
+# authenticate against Zapier's platform with a deploy key
+zapier-platform login
+
+# install dependencies
+pnpm install
+```
+
+## Testing
+
+```sh
+pnpm lint       # oxlint + oxfmt
+pnpm test       # unit tests (vitest, 100% coverage enforced)
+pnpm test:e2e   # end-to-end suite against a real Ghost
+```
+
+`pnpm test:e2e` is self-contained: with Docker running it boots a throwaway
+`ghost:6` container, provisions an owner user and integration, runs the
+suite, and tears everything down again. Alternatives:
+
+- `GHOST_CORE_PATH=/path/to/Ghost pnpm test:e2e` boots Ghost from a source
+  checkout instead (install its dependencies first with
+  `pnpm install --frozen-lockfile --filter ghost...`)
+- run any **fresh** Ghost install yourself, then
+  `node test-e2e/setup/bootstrap.js` (set `GHOST_URL` if it is not on
+  `http://localhost:2368`) followed by `pnpm test:e2e`
+
+## Deployment
+
+The integration is deployed to Zapier's platform (app `1566`) with the
+`zapier-platform` CLI; versions are pushed, promoted, and migrated by hand.
+The full runbook — private and public releases, staged user migration, and
+testing a private version against a local Ghost — lives in
+[docs/deployment.md](docs/deployment.md).
 
 ## Useful resources
 
-- [Integration review guidelines](https://platform.zapier.com/partners/integration-review-guidelines) - guidelines on best practices when publishing a new integration. Useful to keep in mind when developing new features
-- [A guideline](https://zapier.com/developer/documentation/v2/planning-guide-v1/#update-actions) about how to best approach feature design in Zapier integration.
+- [Zapier Platform CLI overview](https://docs.zapier.com/integrations/build-cli/overview)
+- [Zapier Platform CLI reference](https://docs.zapier.com/integrations/reference/cli-docs)
+- [Integration checks reference](https://docs.zapier.com/integrations/publish/integration-checks-reference)
+  — Zapier's best practices, useful to keep in mind when developing new
+  features
 
-## Local Testing
+# Copyright & License
 
-- `zapier-platform test` will run the tests
-- `zapier-platform test --debug` will test and output request and response logs
-
-## Deploying
-
-There are couple usecases where you would need to do a deploy:
-1. When releasing a new "private" version for testing by invited users
-2. When releasing a "public" version into the wild
-3. Migrate existing integration users to a newly released version
-
-#### To deploy a "private" version:
-1. bump the version in `package.json` (do not commit)
-2. `zapier-platform push`
-
-Tips:
-- to test if the private version works in "close-to-live" environment you can migrate a single user account's Zaps to the new version by running: `zapier-platform migrate 2.4.0 2.4.1 --user=user@example.com`. Check if the migrations completed through `zapier-platform history`.
-
-#### To deploy a "public" version:
-1. bump the version in `package.json`
-2. update `CHANGELOG.md`
-3. commit above changes with a message matching a new version, e.g. `git commit -m "2.4.0"`
-4. add a tag with a new version, e.g. `git tag 2.4.0`
-5. push out new commit and a tag upstream e.g. `git push upstream main --tags`
-6. `zapier-platform push`
-7. `zapier-platform promote {newVersion}` - only new integrations will use this version
-
-#### To migrate existing users to a new version
-1. `zapier-platform migrate {oldVersion} {newVersion} {percentage}`, eg: `zapier-platform migrate 2.3.1 2.4.0 10`, move 10% of users between versions (recommended to do gradual rollout and monitor for errors before migrating 100% to a new version). Note that since 2026-02-26 Zapier blocks migrating users across integration major versions, so new pushed versions must stay within the current major.
-2. `zapier-platform history` to check migration status, continue once 100% complete
-
-Full [Zapier reference](https://docs.zapier.com/platform/reference/cli-docs#deploying-an-app-version) for deploying a new version.
-
-## Testing Zaps locally
-Before releasing a new version a common thing to do is checking if the changes work in production-like environment. Follow these steps to debug Zapier requests on a local Ghost instance:
-1. Deploy a "private" version descrived in the #Deploying section. Make sure to follow the migration instruction to add yourself to the private version users pool.
-2. Expose your local Ghost instance to the world to be able to reach it from Zapier side. As a one-liner can use `ngrok` to do so by running: `ngrok http http://localhost:2368` 
-3. Go to you Zapier account (regular user account) and create a new Zap
-4. When choosing the trigger search for `Ghost` and select the private version under test.
-5. Connect Zapier to your local instance, which is reachable through a URL like `https://8a4e-101-128-86-58.ngrok.io` if ngrok was used.
-6. Create Zap as usual. And test requests will start coming in to your local Ghost instance.
-
-To trigger configured above Zap use your local Ghost instance as usual and the Zaps should start getting triggered as expected. If you don't see any comming through check out Zapier's error dashboard to debug the problem.
-# Copyright & License 
-
-Copyright (c) 2013-2026 Ghost Foundation - Released under the [MIT license](LICENSE).
+Copyright (c) 2013-2026 Ghost Foundation - Released under the [MIT license](LICENSE). Ghost and the Ghost Logo are trademarks of Ghost Foundation Ltd. Please see our [trademark policy](https://ghost.org/trademark/) for info on acceptable usage.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,31 @@ Ghost Admin under `Integrations » Zapier`) and build Zaps from:
 All requests target the unversioned Admin API (`/ghost/api/admin/`) and
 declare their compatibility version via the `Accept-Version` header.
 
+## How it works
+
+Triggers are instant: on Zap activation the app registers a webhook in Ghost,
+and Ghost pushes event payloads to Zapier from then on. Creates and searches
+call the Admin API directly.
+
+```mermaid
+flowchart LR
+    subgraph zapier["Zapier platform (this app)"]
+        auth["Authentication<br/>(Admin API key)"]
+        triggers["Triggers<br/>(REST hooks)"]
+        actions["Creates & Searches"]
+    end
+
+    subgraph ghost["Ghost site"]
+        admin["Admin API<br/>/ghost/api/admin/ + Accept-Version"]
+        webhooks["Webhooks"]
+    end
+
+    auth -- "site version & config check" --> admin
+    triggers -- "subscribe / unsubscribe" --> admin
+    actions -- "posts, members, authors" --> admin
+    webhooks -- "event payloads (instant triggers)" --> triggers
+```
+
 ## Ghost version support
 
 New Zap connections require **Ghost 6.0 or later**. Authentication reads

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,74 @@
+# Deployment
+
+How the Ghost integration is versioned, released, and rolled out on Zapier's
+platform. Deploys are manual and human-owned — nothing in CI pushes to Zapier.
+
+## Prerequisites
+
+- The `zapier-platform` CLI, installed globally:
+  `npm install --global zapier-platform-cli` (the binary is called
+  `zapier-platform` since v19)
+- Authentication against Zapier's platform with a deploy key:
+  `zapier-platform login`
+- The integration is Zapier app `1566` (`App1566`), pinned in `.zapierapprc`
+
+## Versioning rules
+
+- The integration version lives in `package.json` and is bumped by hand as
+  part of a release — never by automation.
+- **Stay within the current major.** Since 2026-02-26 Zapier blocks migrating
+  users across integration major versions, so a version pushed under a new
+  major can never receive existing users. Users on old majors stay pinned to
+  the integration versions their Zaps were created with.
+
+## Releasing a private version (invite-only testing)
+
+1. Bump the version in `package.json` (do not commit)
+2. `zapier-platform push`
+
+To test the private version in a close-to-live environment, migrate a single
+user account's Zaps to it:
+
+```sh
+zapier-platform migrate 2.4.0 2.4.1 --user=user@example.com
+zapier-platform history   # check the migration completed
+```
+
+## Releasing a public version
+
+1. Bump the version in `package.json`
+2. Update `CHANGELOG.md`
+3. Commit both changes with a message matching the new version, e.g.
+   `git commit -m "2.4.0"`
+4. Tag the commit: `git tag 2.4.0`
+5. Push the commit and tag upstream: `git push upstream main --tags`
+6. `zapier-platform push`
+7. `zapier-platform promote 2.4.0` — from here on, new connections use this
+   version; existing users stay where they are until migrated
+
+## Migrating existing users to a new version
+
+1. `zapier-platform migrate {oldVersion} {newVersion} {percentage}`, e.g.
+   `zapier-platform migrate 2.3.1 2.4.0 10` moves 10% of users. Roll out
+   gradually and watch Zapier's error dashboard before migrating 100%.
+   Remember that cross-major migrations are blocked (see
+   [Versioning rules](#versioning-rules)).
+2. `zapier-platform history` — check migration status and continue once the
+   step reports 100% complete.
+
+Zapier's own reference:
+[deploying an integration version](https://docs.zapier.com/integrations/reference/cli-docs#deploying-an-integration-version).
+
+## Testing a private version against a local Ghost
+
+To check changes against a production-like setup before promoting:
+
+1. Release a private version and migrate your own account to it (see above).
+2. Expose your local Ghost instance so Zapier can reach it, e.g.
+   `ngrok http http://localhost:2368`.
+3. In your regular Zapier account, create a new Zap and select the Ghost
+   private version under test.
+4. Connect it to your local instance via the public URL ngrok printed.
+5. Use your local Ghost as usual — webhook deliveries and API requests from
+   Zapier now hit it. If nothing comes through, check Zapier's error
+   dashboard.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -64,11 +64,13 @@ Zapier's own reference:
 To check changes against a production-like setup before promoting:
 
 1. Release a private version and migrate your own account to it (see above).
-2. Expose your local Ghost instance so Zapier can reach it, e.g.
-   `ngrok http http://localhost:2368`.
+2. Expose your local Ghost instance so Zapier can reach it — we use
+   [Tailscale Funnel](https://tailscale.com/kb/1223/funnel):
+   `tailscale funnel 2368`. (Any tunnel that gives you a public HTTPS URL
+   works, e.g. `ngrok http http://localhost:2368`.)
 3. In your regular Zapier account, create a new Zap and select the Ghost
    private version under test.
-4. Connect it to your local instance via the public URL ngrok printed.
+4. Connect it to your local instance via the public URL the tunnel printed.
 5. Use your local Ghost as usual — webhook deliveries and API requests from
    Zapier now hit it. If nothing comes through, check Zapier's error
    dashboard.


### PR DESCRIPTION
Docs pass for the Clean Repos workflow, one commit per concern:

- **README rework** — coherent rewrite instead of another patch: what-it-is intro, Ghost 6+ support statement, pnpm quick-start, the self-contained `pnpm test:e2e` story with `GHOST_CORE_PATH`/`GHOST_URL` overrides, stale `platform.zapier.com` 404s replaced with verified `docs.zapier.com/integrations` links, deploy detail linked out instead of inlined.
- **Supporting docs** — removed the `docs` line from `.gitignore` (it blocked the directory) and moved the deploy/versioning/migration runbook into `docs/deployment.md`, including the cross-major migration rule, staged rollout guidance, changelog-on-promote, and the App1566/deploy-key notes.
- **AGENTS.md** — commands, boundaries (no `zapier-platform push`/`promote`/`migrate` from automation, owner-managed version, 100% coverage gates, the single-sourced Ghost floor in `app/lib/utils.js`, the Renovate guards and why), and conventions; `CLAUDE.md` is a symlink to it.
- **Diagram** — one Mermaid flowchart of the runtime topology (Ghost webhooks → REST-hook triggers vs creates/searches → unversioned Admin API + Accept-Version, auth via Admin API key) in the README overview; syntax verified with mermaid-cli.
- **CODEOWNERS removal** — deleted `.github/CODEOWNERS` (`* @royalfig` conflicts with repo-meta ownership; no team convention exists), per the recorded owner decision.

Verified: `pnpm lint` and `pnpm test` green (no code changes), README prose 457 words, every internal path and external link resolves (curl-checked incl. anchors).

ref [GVA-831](https://linear.app/ghost/issue/GVA-831/clean-repos-zapier)