### PR TITLE
Close out dependency-hygiene gaps from the final review

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,5 +31,10 @@
     "oxfmt": "0.57.0",
     "oxlint": "1.72.0",
     "vitest": "4.1.9"
+  },
+  "pnpm": {
+    "overrides": {
+      "form-data@<4.0.6": ">=4.0.6"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  form-data@<4.0.6: '>=4.0.6'
+
 importers:
 
   .:
@@ -656,8 +659,8 @@ packages:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
 
-  form-data@4.0.5:
-    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
 
   fsevents@2.3.3:
@@ -1445,7 +1448,7 @@ snapshots:
   '@tryghost/admin-api@1.14.10':
     dependencies:
       axios: 1.17.0
-      form-data: 4.0.5
+      form-data: 4.0.6
       jsonwebtoken: 9.0.3
     transitivePeerDependencies:
       - debug
@@ -1553,7 +1556,7 @@ snapshots:
   axios@1.17.0:
     dependencies:
       follow-redirects: 1.16.0
-      form-data: 4.0.5
+      form-data: 4.0.6
       https-proxy-agent: 5.0.1
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
@@ -1673,7 +1676,7 @@ snapshots:
     dependencies:
       is-callable: 1.2.7
 
-  form-data@4.0.5:
+  form-data@4.0.6:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
@@ -2172,7 +2175,7 @@ snapshots:
       content-disposition: 0.5.4
       dotenv: 17.2.1
       fernet: 0.3.3
-      form-data: 4.0.5
+      form-data: 4.0.6
       json-schema-to-ts: 3.1.1
       lodash: 4.18.1
       mime-types: 3.0.1

--- a/renovate.json5
+++ b/renovate.json5
@@ -15,8 +15,8 @@
             allowedVersions: '<11',
         },
         {
-            description: "Keep the e2e job's setup-node on Node 22: it boots Ghost from source and follows Ghost's engines (^22.18.0). The shared preset automerges uses-with bumps, so without this rule a major bump to Node 24 would silently drift e2e off Ghost's supported runtime. Patch/minor bumps within 22 stay in range and may automerge.",
-            matchManagers: ['github-actions'],
+            description: "Keep Node updates on 22: the Zapier Lambda runtime for core 19 is Node 22, the e2e job follows Ghost's engines (^22.18.0), and `.nvmrc` mirrors both. The shared preset automerges these bumps, so without this rule a major bump to Node 24 would silently drift CI and local dev off the deployed runtime. Patch/minor bumps within 22 stay in range and may automerge.",
+            matchManagers: ['github-actions', 'nvm'],
             matchPackageNames: ['node'],
             allowedVersions: '<23',
         },


### PR DESCRIPTION
Two residuals from the Clean Repos final gap review:

1. **Node 22 guard extended to `.nvmrc`** — the `<23` rule matched only the github-actions manager, so Renovate's nvm manager could bump `.nvmrc` to Node 24 (stale PR #110 demonstrated exactly that; closed separately). One rule now covers both managers. Validator: clean.
2. **Dependabot alert #113 fixed** — transitive `form-data` 4.0.5 → 4.0.6 (high, CRLF injection) via a scoped pnpm override (`form-data@<4.0.6 → >=4.0.6`) that only rewrites vulnerable ranges and becomes inert once dependents require the fixed version. This was the **last open vulnerability alert** (48 at run start).

Verification: `pnpm install`, `pnpm lint`, `pnpm test` (96 passing, 100% gates), renovate-config-validator clean.

ref [GVA-831](https://linear.app/ghost/issue/GVA-831/clean-repos-zapier)