### PR TITLE
Allow comping members into a specific tier and removing comps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,9 @@ via `node test-e2e/setup/bootstrap.js` (set `GHOST_URL` if it is not on
 
 - The e2e specs share state (02-creates seeds fixtures the later specs assert
   on) and run one file at a time in filename order — `vitest.e2e.config.js`
-  enforces this. Don't parallelise them or renumber the files.
+  enforces this. Don't parallelise them or renumber the files. Order matters
+  within 02-creates too: `fixtures.member` must be created last so it stays
+  the newest member for the member trigger performList assertions.
 - The `sample` objects in `app/` triggers/creates/searches mirror real
   Ghost 6 API shapes and are shown to users in the Zap editor — don't trim
   or invent fields.

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Zapier users connect their Ghost site with an Admin API key and URL (from
 Ghost Admin under `Integrations » Zapier`) and build Zaps from:
 
 - **Triggers** — instant REST hooks fed by Ghost webhooks: post/page
-  published, post scheduled, member created/updated/deleted, tag, author, and
-  newsletter created
+  published, post scheduled, member created/updated/deleted, tag, author,
+  newsletter, and tier created
 - **Creates** — create a post, create or update a member
 - **Searches** — find a member or an author
 

--- a/app/creates/create_member.js
+++ b/app/creates/create_member.js
@@ -1,4 +1,4 @@
-const { initAdminApi } = require('../lib/utils');
+const { initAdminApi, isEnabled } = require('../lib/utils');
 
 const createMember = async (z, bundle) => {
     const memberData = {
@@ -33,8 +33,9 @@ const createMember = async (z, bundle) => {
     }
 
     // a specific complimentary tier and the deprecated default-tier boolean
-    // are mutually exclusive - error rather than guess which one was meant
-    if (bundle.inputData.comped_tier && bundle.inputData.comped) {
+    // are mutually exclusive - error rather than guess which one was meant.
+    // isEnabled keeps a stringified 'false' from tripping the error
+    if (bundle.inputData.comped_tier && isEnabled(bundle.inputData.comped)) {
         throw new z.errors.HaltedError(
             'Use either "Complimentary tier" or the deprecated "Complimentary premium plan", not both.',
         );

--- a/app/creates/create_member.js
+++ b/app/creates/create_member.js
@@ -32,7 +32,17 @@ const createMember = async (z, bundle) => {
         memberData.labels = bundle.inputData.labels;
     }
 
-    if (bundle.inputData.comped) {
+    // a specific complimentary tier and the deprecated default-tier boolean
+    // are mutually exclusive - error rather than guess which one was meant
+    if (bundle.inputData.comped_tier && bundle.inputData.comped) {
+        throw new z.errors.HaltedError(
+            'Use either "Complimentary tier" or the deprecated "Complimentary premium plan", not both.',
+        );
+    }
+
+    if (bundle.inputData.comped_tier) {
+        memberData.tiers = [{ id: bundle.inputData.comped_tier }];
+    } else if (bundle.inputData.comped) {
         memberData.comped = bundle.inputData.comped;
     }
 
@@ -161,11 +171,19 @@ module.exports = {
                 ],
             },
             {
+                key: 'comped_tier',
+                label: 'Complimentary tier',
+                required: false,
+                dynamic: 'tier_created.id.name',
+                helpText:
+                    'Give the member a free of charge subscription to a specific paid tier. Cannot be combined with "Complimentary premium plan".',
+            },
+            {
                 key: 'comped',
                 label: 'Complimentary premium plan',
                 type: 'boolean',
                 helpText:
-                    'If enabled, member will be placed onto a free of charge premium subscription',
+                    'Deprecated - use "Complimentary tier" instead. If enabled, member will be placed onto a free of charge premium subscription to the default tier. Requires a connected Stripe account.',
             },
         ],
 

--- a/app/creates/update_member.js
+++ b/app/creates/update_member.js
@@ -160,14 +160,14 @@ module.exports = {
                 required: false,
                 dynamic: 'tier_created.id.name',
                 helpText:
-                    'Give the member a free of charge subscription to a specific paid tier. Cannot be combined with the other complimentary fields.',
+                    "Give the member a free of charge subscription to a specific paid tier. Cannot be combined with the other complimentary fields. On sites without a connected Stripe account the tier is attached, but the member's status is not recalculated until Stripe is connected.",
             },
             {
                 key: 'comped_remove',
                 label: 'Remove complimentary subscriptions',
                 type: 'boolean',
                 helpText:
-                    'If enabled, all complimentary subscriptions are removed from the member. Cannot be combined with the other complimentary fields.',
+                    'If enabled, all complimentary subscriptions are removed from the member. Cannot be combined with the other complimentary fields. On sites without a connected Stripe account the tiers are detached, but the member keeps a comped status until Stripe is connected.',
             },
             {
                 key: 'comped',

--- a/app/creates/update_member.js
+++ b/app/creates/update_member.js
@@ -33,7 +33,29 @@ const updateMember = async (z, bundle) => {
         memberData.labels = bundle.inputData.labels;
     }
 
-    if (bundle.inputData.comped !== undefined) {
+    // the three complimentary inputs are mutually exclusive - error rather
+    // than guess which one was meant. `comped` counts as used when it is set
+    // at all because `false` actively removes a comp via the deprecated path
+    if (bundle.inputData.comped_tier && bundle.inputData.comped_remove) {
+        throw new z.errors.HaltedError(
+            'Use either "Complimentary tier" or "Remove complimentary subscriptions", not both.',
+        );
+    }
+    if (
+        (bundle.inputData.comped_tier || bundle.inputData.comped_remove) &&
+        bundle.inputData.comped !== undefined
+    ) {
+        throw new z.errors.HaltedError(
+            'The deprecated "Complimentary premium plan" field cannot be combined with "Complimentary tier" or "Remove complimentary subscriptions" - leave it blank.',
+        );
+    }
+
+    if (bundle.inputData.comped_tier) {
+        memberData.tiers = [{ id: bundle.inputData.comped_tier }];
+    } else if (bundle.inputData.comped_remove) {
+        // an empty tiers array removes all complimentary subscriptions
+        memberData.tiers = [];
+    } else if (bundle.inputData.comped !== undefined) {
         memberData.comped = bundle.inputData.comped;
     }
 
@@ -133,11 +155,26 @@ module.exports = {
                 helpText: 'Provide a list of labels to attach to the member',
             },
             {
+                key: 'comped_tier',
+                label: 'Complimentary tier',
+                required: false,
+                dynamic: 'tier_created.id.name',
+                helpText:
+                    'Give the member a free of charge subscription to a specific paid tier. Cannot be combined with the other complimentary fields.',
+            },
+            {
+                key: 'comped_remove',
+                label: 'Remove complimentary subscriptions',
+                type: 'boolean',
+                helpText:
+                    'If enabled, all complimentary subscriptions are removed from the member. Cannot be combined with the other complimentary fields.',
+            },
+            {
                 key: 'comped',
                 label: 'Complimentary premium plan',
                 type: 'boolean',
                 helpText:
-                    'If enabled, member will be placed onto a free of charge premium subscription',
+                    'Deprecated - use "Complimentary tier" or "Remove complimentary subscriptions" instead. If enabled, member will be placed onto a free of charge premium subscription to the default tier; if disabled, an existing one is removed. Requires a connected Stripe account.',
             },
         ],
 

--- a/app/creates/update_member.js
+++ b/app/creates/update_member.js
@@ -1,4 +1,4 @@
-const { initAdminApi } = require('../lib/utils');
+const { initAdminApi, isEnabled } = require('../lib/utils');
 
 const updateMember = async (z, bundle) => {
     const memberData = {
@@ -33,18 +33,18 @@ const updateMember = async (z, bundle) => {
         memberData.labels = bundle.inputData.labels;
     }
 
+    // isEnabled keeps a stringified 'false' from removing comps by accident
+    const removeComped = isEnabled(bundle.inputData.comped_remove);
+
     // the three complimentary inputs are mutually exclusive - error rather
     // than guess which one was meant. `comped` counts as used when it is set
     // at all because `false` actively removes a comp via the deprecated path
-    if (bundle.inputData.comped_tier && bundle.inputData.comped_remove) {
+    if (bundle.inputData.comped_tier && removeComped) {
         throw new z.errors.HaltedError(
             'Use either "Complimentary tier" or "Remove complimentary subscriptions", not both.',
         );
     }
-    if (
-        (bundle.inputData.comped_tier || bundle.inputData.comped_remove) &&
-        bundle.inputData.comped !== undefined
-    ) {
+    if ((bundle.inputData.comped_tier || removeComped) && bundle.inputData.comped !== undefined) {
         throw new z.errors.HaltedError(
             'The deprecated "Complimentary premium plan" field cannot be combined with "Complimentary tier" or "Remove complimentary subscriptions" - leave it blank.',
         );
@@ -52,7 +52,7 @@ const updateMember = async (z, bundle) => {
 
     if (bundle.inputData.comped_tier) {
         memberData.tiers = [{ id: bundle.inputData.comped_tier }];
-    } else if (bundle.inputData.comped_remove) {
+    } else if (removeComped) {
         // an empty tiers array removes all complimentary subscriptions
         memberData.tiers = [];
     } else if (bundle.inputData.comped !== undefined) {

--- a/app/lib/utils.js
+++ b/app/lib/utils.js
@@ -1,4 +1,8 @@
 const GhostAdminApi = require('@tryghost/admin-api');
+// the SDK does not re-export its token signer, but the grafted tiers
+// resource in initAdminApi needs it to authenticate like the SDK resources
+// do - a moved file would fail at require time and every test would catch it
+const generateToken = require('@tryghost/admin-api/lib/token');
 const packageInfo = require('../../package.json');
 const packageVersion = packageInfo.version;
 
@@ -67,7 +71,7 @@ const initAdminApi = (z, { adminApiUrl: adminUrl, adminApiKey: key }) => {
             });
     }
 
-    return new GhostAdminApi({
+    const api = new GhostAdminApi({
         url: adminUrl,
         key,
         makeRequest,
@@ -75,6 +79,27 @@ const initAdminApi = (z, { adminApiUrl: adminUrl, adminApiKey: key }) => {
         // endpoints and is sent as the Accept-Version request header
         version: ADMIN_API_VERSION,
     });
+
+    // @tryghost/admin-api 1.14.10 has no tiers resource, so graft a
+    // browse-only one on. It goes through the same makeRequest as the SDK
+    // resources, keeping error handling and the User-Agent prefix identical.
+    api.tiers = {
+        browse(params = {}) {
+            return makeRequest({
+                url: `${adminUrl}/ghost/api/admin/tiers/`,
+                method: 'GET',
+                params,
+                headers: {
+                    // '/admin/' is the token audience for the unversioned
+                    // Admin API - the same value the SDK derives internally
+                    Authorization: `Ghost ${generateToken(key, '/admin/')}`,
+                    'Accept-Version': ADMIN_API_VERSION,
+                },
+            }).then((data) => data.tiers);
+        },
+    };
+
+    return api;
 };
 
 /**

--- a/app/lib/utils.js
+++ b/app/lib/utils.js
@@ -114,8 +114,21 @@ const isNotFoundHaltedError = (err) => {
     return err.name === 'HaltedError' && err.status === 404;
 };
 
+/**
+ * Zapier boolean inputs occasionally arrive stringified (see the
+ * `newsletters_default` guards in the member creates), so a plain truthy
+ * check would treat 'false' as enabled. Only real and stringified true count.
+ *
+ * @param {boolean|string|undefined} value a boolean input field's value
+ * @returns {boolean}
+ */
+const isEnabled = (value) => {
+    return value === true || value === 'true';
+};
+
 module.exports = {
     initAdminApi,
+    isEnabled,
     isNotFoundHaltedError,
     RequestError,
     SUPPORTED_GHOST_VERSION,

--- a/app/triggers/index.js
+++ b/app/triggers/index.js
@@ -8,4 +8,5 @@ module.exports = {
     post_scheduled: require('./post_scheduled'),
     tag_created: require('./tag_created'),
     newsletter_created: require('./newsletter_created'),
+    tier_created: require('./tier_created'),
 };

--- a/app/triggers/tier_created.js
+++ b/app/triggers/tier_created.js
@@ -1,0 +1,85 @@
+const { initAdminApi } = require('../lib/utils');
+const webhooks = require('../lib/webhooks');
+
+const subscribeWebhook = (z, bundle) => {
+    return webhooks.subscribe('tier.added', z, bundle);
+};
+
+const unsubscribeWebhook = (z, bundle) => {
+    return webhooks.unsubscribe(z, bundle);
+};
+
+// triggers on tier.added. Formats the API response ready for passing to
+// the zap which expects an array
+const handleWebhook = (z, bundle) => {
+    // bundle.cleanedRequest will include the parsed JSON object (if it's not a
+    // test poll) and also a .querystring property with the URL's query string.
+    const { tier } = bundle.cleanedRequest;
+
+    return [tier.current];
+};
+
+// complimentary subscriptions only make sense for active paid tiers - the
+// same set Ghost Admin's own "Make complimentary" UI offers
+const TIER_FILTER = 'type:paid+active:true';
+
+const listTiers = (z, bundle) => {
+    const { authData, meta } = bundle;
+
+    const api = initAdminApi(z, authData);
+
+    if (meta.isFillingDynamicDropdown) {
+        return api.tiers.browse({
+            filter: TIER_FILTER,
+            order: 'name DESC',
+            limit: 'all',
+        });
+    }
+
+    return api.tiers.browse({
+        filter: TIER_FILTER,
+        order: 'created_at DESC',
+        limit: 1,
+    });
+};
+
+module.exports = {
+    key: 'tier_created',
+    noun: 'Tier',
+
+    display: {
+        label: 'Tier Created',
+        description: 'Triggers when a new tier is added.',
+        hidden: true, // only used by tier dynamic dropdown
+    },
+
+    operation: {
+        inputFields: [],
+
+        type: 'hook',
+
+        performSubscribe: subscribeWebhook,
+        performUnsubscribe: unsubscribeWebhook,
+
+        perform: handleWebhook,
+        performList: listTiers,
+
+        sample: {
+            id: '6220aa04dd8021001c50e6e2',
+            name: 'Premium',
+            description: null,
+            slug: 'premium',
+            active: true,
+            type: 'paid',
+            welcome_page_url: null,
+            created_at: '2022-03-03T11:16:52.000Z',
+            updated_at: '2022-03-03T11:16:52.000Z',
+            visibility: 'public',
+            benefits: [],
+            currency: 'USD',
+            monthly_price: 500,
+            yearly_price: 5000,
+            trial_days: 0,
+        },
+    },
+};

--- a/test-e2e/02-creates.test.js
+++ b/test-e2e/02-creates.test.js
@@ -11,6 +11,108 @@ describe('E2E Creates', function () {
         authData = getAuthData();
     });
 
+    // runs before 'Create Member' so fixtures.member stays the newest member
+    // (the trigger specs assert on the latest member) - see helpers.js
+    describe('Complimentary tiers', function () {
+        let paidTier;
+
+        beforeAll(async function () {
+            // a fresh Ghost install ships with one active paid tier named
+            // after the site, even without Stripe connected
+            const tiers = await appTester(App.triggers.tier_created.operation.performList, {
+                authData,
+                meta: { isFillingDynamicDropdown: true },
+            });
+
+            expect(tiers).toHaveLength(1);
+            expect(tiers[0].type).toBe('paid');
+            expect(tiers[0].active).toBe(true);
+            expect(tiers[0].name).toBe(OWNER.blogTitle);
+
+            paidTier = tiers[0];
+        });
+
+        it('creates a comped member without Stripe connected', async function () {
+            const member = await appTester(App.creates.create_member.operation.perform, {
+                authData,
+                inputData: {
+                    name: fixtures.compedMember.name,
+                    email: fixtures.compedMember.email,
+                    comped_tier: paidTier.id,
+                    send_email: false,
+                },
+            });
+
+            expect(member.email).toBe(fixtures.compedMember.email);
+            expect(member.status).toBe('comped');
+            expect(member.tiers).toHaveLength(1);
+            expect(member.tiers[0].id).toBe(paidTier.id);
+        });
+
+        it('removes complimentary subscriptions but Ghost keeps the comped status without Stripe', async function () {
+            const [member] = await appTester(App.searches.member.operation.perform, {
+                authData,
+                inputData: { email: fixtures.compedMember.email },
+            });
+
+            const updated = await appTester(App.creates.update_member.operation.perform, {
+                authData,
+                inputData: {
+                    id: member.id,
+                    comped_remove: true,
+                },
+            });
+
+            expect(updated.tiers).toHaveLength(0);
+            // without Stripe, Ghost skips its member status recalculation on
+            // edit (`needsProducts` is Stripe-gated in the member repository),
+            // so the tier is detached but the status is left as it was
+            expect(updated.status).toBe('comped');
+        });
+
+        it('attaches a tier on update but Ghost keeps the free status without Stripe', async function () {
+            const created = await appTester(App.creates.create_member.operation.perform, {
+                authData,
+                inputData: {
+                    name: fixtures.tieredMember.name,
+                    email: fixtures.tieredMember.email,
+                    send_email: false,
+                },
+            });
+            expect(created.status).toBe('free');
+
+            const updated = await appTester(App.creates.update_member.operation.perform, {
+                authData,
+                inputData: {
+                    id: created.id,
+                    comped_tier: paidTier.id,
+                },
+            });
+
+            expect(updated.tiers).toHaveLength(1);
+            expect(updated.tiers[0].id).toBe(paidTier.id);
+            // the same Stripe-gated status recalculation as above: on a
+            // Stripe-connected site this member would become 'comped'
+            expect(updated.status).toBe('free');
+        });
+
+        it('rejects the deprecated comped flag without Stripe connected', async function () {
+            await expect(
+                appTester(App.creates.create_member.operation.perform, {
+                    authData,
+                    inputData: {
+                        email: 'e2e-legacy-comped@example.com',
+                        comped: true,
+                        send_email: false,
+                    },
+                }),
+            ).rejects.toMatchObject({
+                name: 'HaltedError',
+                message: expect.stringMatching(/Missing Stripe connection/),
+            });
+        });
+    });
+
     describe('Create Member', function () {
         it('creates a member without sending an email', async function () {
             const member = await appTester(App.creates.create_member.operation.perform, {

--- a/test-e2e/04-triggers.test.js
+++ b/test-e2e/04-triggers.test.js
@@ -70,6 +70,14 @@ describe('E2E Trigger performLists', function () {
         expect(tag.slug).toBe(fixtures.tagSlug);
     });
 
+    it('tier_created lists the default paid tier and excludes the free tier', async function () {
+        const tiers = await performList('tier_created');
+
+        expect(tiers).toHaveLength(1);
+        expect(tiers[0].type).toBe('paid');
+        expect(tiers[0].name).toBe(OWNER.blogTitle);
+    });
+
     it('author_created lists the owner user', async function () {
         const [author] = await performList('author_created');
 

--- a/test-e2e/05-webhooks.test.js
+++ b/test-e2e/05-webhooks.test.js
@@ -14,6 +14,7 @@ const HOOK_TRIGGERS = [
     'member_updated',
     'member_deleted',
     'newsletter_created',
+    'tier_created',
 ];
 
 HOOK_TRIGGERS.forEach(function (triggerKey) {

--- a/test-e2e/helpers.js
+++ b/test-e2e/helpers.js
@@ -69,6 +69,17 @@ const fixtures = {
         email: 'e2e-member@example.com',
         note: 'Created by the Zapier e2e suite',
     },
+    // members used by the complimentary tier specs - created before `member`
+    // so that `member` stays the newest member (member_created/member_deleted
+    // performLists assert on the latest member)
+    compedMember: {
+        name: 'E2E Comped Member',
+        email: 'e2e-comped-member@example.com',
+    },
+    tieredMember: {
+        name: 'E2E Tiered Member',
+        email: 'e2e-tiered-member@example.com',
+    },
     publishedPost: {
         title: 'E2E Published Post',
         html: '<p>Published by the Zapier e2e suite.</p>',

--- a/test/creates/create_member.test.js
+++ b/test/creates/create_member.test.js
@@ -439,6 +439,55 @@ describe('Creates', function () {
             });
         });
 
+        it('allows a complimentary tier alongside an unchecked comped flag', function () {
+            // comped: false is a no-op on create, so it does not count as
+            // using the deprecated mechanism - only a truthy comped conflicts
+            let bundle = Object.assign(
+                {},
+                { authData },
+                {
+                    inputData: {
+                        name: 'Test Member',
+                        email: 'test@example.com',
+                        comped: false,
+                        comped_tier: '6220aa04dd8021001c50e6e2',
+                    },
+                },
+            );
+
+            apiMock
+                .post('/ghost/api/admin/members/?send_email=true', {
+                    members: [
+                        {
+                            name: 'Test Member',
+                            email: 'test@example.com',
+                            tiers: [{ id: '6220aa04dd8021001c50e6e2' }],
+                        },
+                    ],
+                })
+                .reply(201, {
+                    members: [
+                        {
+                            id: '5c9c9c8d51b5bf974afad2a4',
+                            name: 'Test Member',
+                            email: 'test@example.com',
+                            status: 'comped',
+                            comped: true,
+                            labels: [],
+                            created_at: '2019-10-03T11:54:10.123Z',
+                            updated_at: '2019-10-03T11:54:10.123Z',
+                        },
+                    ],
+                });
+
+            return appTester(App.creates.create_member.operation.perform, bundle).then((member) => {
+                expect(apiMock.isDone()).toBe(true);
+
+                expect(member.id).toBe('5c9c9c8d51b5bf974afad2a4');
+                expect(member.status).toBe('comped');
+            });
+        });
+
         it('rejects combining a complimentary tier with the deprecated comped flag', function () {
             let bundle = Object.assign(
                 {},

--- a/test/creates/create_member.test.js
+++ b/test/creates/create_member.test.js
@@ -439,54 +439,64 @@ describe('Creates', function () {
             });
         });
 
-        it('allows a complimentary tier alongside an unchecked comped flag', function () {
-            // comped: false is a no-op on create, so it does not count as
-            // using the deprecated mechanism - only a truthy comped conflicts
-            let bundle = Object.assign(
-                {},
-                { authData },
-                {
-                    inputData: {
-                        name: 'Test Member',
-                        email: 'test@example.com',
-                        comped: false,
-                        comped_tier: '6220aa04dd8021001c50e6e2',
+        it.each([
+            ['boolean', false],
+            // Zapier boolean inputs occasionally arrive stringified - a
+            // 'false' string must not count as using the deprecated mechanism
+            ['stringified', 'false'],
+        ])(
+            'allows a complimentary tier alongside an unchecked %s comped flag',
+            function (_, comped) {
+                // comped: false is a no-op on create, so it does not count as
+                // using the deprecated mechanism - only a true comped conflicts
+                let bundle = Object.assign(
+                    {},
+                    { authData },
+                    {
+                        inputData: {
+                            name: 'Test Member',
+                            email: 'test@example.com',
+                            comped,
+                            comped_tier: '6220aa04dd8021001c50e6e2',
+                        },
                     },
-                },
-            );
+                );
 
-            apiMock
-                .post('/ghost/api/admin/members/?send_email=true', {
-                    members: [
-                        {
-                            name: 'Test Member',
-                            email: 'test@example.com',
-                            tiers: [{ id: '6220aa04dd8021001c50e6e2' }],
-                        },
-                    ],
-                })
-                .reply(201, {
-                    members: [
-                        {
-                            id: '5c9c9c8d51b5bf974afad2a4',
-                            name: 'Test Member',
-                            email: 'test@example.com',
-                            status: 'comped',
-                            comped: true,
-                            labels: [],
-                            created_at: '2019-10-03T11:54:10.123Z',
-                            updated_at: '2019-10-03T11:54:10.123Z',
-                        },
-                    ],
-                });
+                apiMock
+                    .post('/ghost/api/admin/members/?send_email=true', {
+                        members: [
+                            {
+                                name: 'Test Member',
+                                email: 'test@example.com',
+                                tiers: [{ id: '6220aa04dd8021001c50e6e2' }],
+                            },
+                        ],
+                    })
+                    .reply(201, {
+                        members: [
+                            {
+                                id: '5c9c9c8d51b5bf974afad2a4',
+                                name: 'Test Member',
+                                email: 'test@example.com',
+                                status: 'comped',
+                                comped: true,
+                                labels: [],
+                                created_at: '2019-10-03T11:54:10.123Z',
+                                updated_at: '2019-10-03T11:54:10.123Z',
+                            },
+                        ],
+                    });
 
-            return appTester(App.creates.create_member.operation.perform, bundle).then((member) => {
-                expect(apiMock.isDone()).toBe(true);
+                return appTester(App.creates.create_member.operation.perform, bundle).then(
+                    (member) => {
+                        expect(apiMock.isDone()).toBe(true);
 
-                expect(member.id).toBe('5c9c9c8d51b5bf974afad2a4');
-                expect(member.status).toBe('comped');
-            });
-        });
+                        expect(member.id).toBe('5c9c9c8d51b5bf974afad2a4');
+                        expect(member.status).toBe('comped');
+                    },
+                );
+            },
+        );
 
         it('rejects combining a complimentary tier with the deprecated comped flag', function () {
             let bundle = Object.assign(

--- a/test/creates/create_member.test.js
+++ b/test/creates/create_member.test.js
@@ -393,6 +393,76 @@ describe('Creates', function () {
             });
         });
 
+        it('creates a member with a complimentary tier', function () {
+            let bundle = Object.assign(
+                {},
+                { authData },
+                {
+                    inputData: {
+                        name: 'Test Member',
+                        email: 'test@example.com',
+                        comped_tier: '6220aa04dd8021001c50e6e2',
+                    },
+                },
+            );
+
+            apiMock
+                .post('/ghost/api/admin/members/?send_email=true', {
+                    members: [
+                        {
+                            name: 'Test Member',
+                            email: 'test@example.com',
+                            tiers: [{ id: '6220aa04dd8021001c50e6e2' }],
+                        },
+                    ],
+                })
+                .reply(201, {
+                    members: [
+                        {
+                            id: '5c9c9c8d51b5bf974afad2a4',
+                            name: 'Test Member',
+                            email: 'test@example.com',
+                            status: 'comped',
+                            comped: true,
+                            labels: [],
+                            created_at: '2019-10-03T11:54:10.123Z',
+                            updated_at: '2019-10-03T11:54:10.123Z',
+                        },
+                    ],
+                });
+
+            return appTester(App.creates.create_member.operation.perform, bundle).then((member) => {
+                expect(apiMock.isDone()).toBe(true);
+
+                expect(member.id).toBe('5c9c9c8d51b5bf974afad2a4');
+                expect(member.status).toBe('comped');
+            });
+        });
+
+        it('rejects combining a complimentary tier with the deprecated comped flag', function () {
+            let bundle = Object.assign(
+                {},
+                { authData },
+                {
+                    inputData: {
+                        email: 'test@example.com',
+                        comped: true,
+                        comped_tier: '6220aa04dd8021001c50e6e2',
+                    },
+                },
+            );
+
+            return appTester(App.creates.create_member.operation.perform, bundle).then(
+                () => {
+                    expect.unreachable('expected the call to be rejected');
+                },
+                (err) => {
+                    expect(err.name).toEqual('HaltedError');
+                    expect(err.message).toMatch(/not both/);
+                },
+            );
+        });
+
         it('creates a member subscribed to multiple newsletters', function () {
             let bundle = Object.assign(
                 {},

--- a/test/creates/update_member.test.js
+++ b/test/creates/update_member.test.js
@@ -408,7 +408,31 @@ describe('Creates', function () {
             );
         });
 
-        it('rejects combining the deprecated comped flag with the new complimentary fields', function () {
+        it('rejects combining the deprecated comped flag with a complimentary tier', function () {
+            let bundle = Object.assign(
+                {},
+                { authData },
+                {
+                    inputData: {
+                        id: '5c9c9c8d51b5bf974afad2a4',
+                        comped: true,
+                        comped_tier: '6220aa04dd8021001c50e6e2',
+                    },
+                },
+            );
+
+            return appTester(App.creates.update_member.operation.perform, bundle).then(
+                () => {
+                    expect.unreachable('expected the call to be rejected');
+                },
+                (err) => {
+                    expect(err.name).toEqual('HaltedError');
+                    expect(err.message).toMatch(/leave it blank/);
+                },
+            );
+        });
+
+        it('rejects combining the deprecated comped flag with the remove flag', function () {
             let bundle = Object.assign(
                 {},
                 { authData },

--- a/test/creates/update_member.test.js
+++ b/test/creates/update_member.test.js
@@ -384,6 +384,96 @@ describe('Creates', function () {
             });
         });
 
+        it('removes complimentary subscriptions when the remove flag arrives stringified', function () {
+            let bundle = Object.assign(
+                {},
+                { authData },
+                {
+                    inputData: {
+                        id: '5c9c9c8d51b5bf974afad2a4',
+                        // Zapier boolean inputs occasionally arrive stringified
+                        comped_remove: 'true',
+                    },
+                },
+            );
+
+            apiMock
+                .put('/ghost/api/admin/members/5c9c9c8d51b5bf974afad2a4/', {
+                    members: [
+                        {
+                            tiers: [],
+                        },
+                    ],
+                })
+                .reply(200, {
+                    members: [
+                        {
+                            id: '5c9c9c8d51b5bf974afad2a4',
+                            name: 'Test Member',
+                            email: 'test@example.com',
+                            status: 'free',
+                            comped: false,
+                            labels: [],
+                            created_at: '2019-10-03T11:54:10.123Z',
+                            updated_at: '2019-10-03T11:54:10.123Z',
+                        },
+                    ],
+                });
+
+            return appTester(App.creates.update_member.operation.perform, bundle).then((member) => {
+                expect(apiMock.isDone()).toBe(true);
+
+                expect(member.id).toBe('5c9c9c8d51b5bf974afad2a4');
+                expect(member.status).toBe('free');
+            });
+        });
+
+        it('ignores a stringified false remove flag next to a complimentary tier', function () {
+            let bundle = Object.assign(
+                {},
+                { authData },
+                {
+                    inputData: {
+                        id: '5c9c9c8d51b5bf974afad2a4',
+                        comped_tier: '6220aa04dd8021001c50e6e2',
+                        // a stringified 'false' must neither remove comps nor
+                        // trip the mutual-exclusion error
+                        comped_remove: 'false',
+                    },
+                },
+            );
+
+            apiMock
+                .put('/ghost/api/admin/members/5c9c9c8d51b5bf974afad2a4/', {
+                    members: [
+                        {
+                            tiers: [{ id: '6220aa04dd8021001c50e6e2' }],
+                        },
+                    ],
+                })
+                .reply(200, {
+                    members: [
+                        {
+                            id: '5c9c9c8d51b5bf974afad2a4',
+                            name: 'Test Member',
+                            email: 'test@example.com',
+                            status: 'comped',
+                            comped: true,
+                            labels: [],
+                            created_at: '2019-10-03T11:54:10.123Z',
+                            updated_at: '2019-10-03T11:54:10.123Z',
+                        },
+                    ],
+                });
+
+            return appTester(App.creates.update_member.operation.perform, bundle).then((member) => {
+                expect(apiMock.isDone()).toBe(true);
+
+                expect(member.id).toBe('5c9c9c8d51b5bf974afad2a4');
+                expect(member.status).toBe('comped');
+            });
+        });
+
         it('rejects combining a complimentary tier with the remove flag', function () {
             let bundle = Object.assign(
                 {},

--- a/test/creates/update_member.test.js
+++ b/test/creates/update_member.test.js
@@ -298,6 +298,141 @@ describe('Creates', function () {
             });
         });
 
+        it('updates a member with a complimentary tier', function () {
+            let bundle = Object.assign(
+                {},
+                { authData },
+                {
+                    inputData: {
+                        id: '5c9c9c8d51b5bf974afad2a4',
+                        comped_tier: '6220aa04dd8021001c50e6e2',
+                    },
+                },
+            );
+
+            apiMock
+                .put('/ghost/api/admin/members/5c9c9c8d51b5bf974afad2a4/', {
+                    members: [
+                        {
+                            tiers: [{ id: '6220aa04dd8021001c50e6e2' }],
+                        },
+                    ],
+                })
+                .reply(200, {
+                    members: [
+                        {
+                            id: '5c9c9c8d51b5bf974afad2a4',
+                            name: 'Test Member',
+                            email: 'test@example.com',
+                            status: 'comped',
+                            comped: true,
+                            labels: [],
+                            created_at: '2019-10-03T11:54:10.123Z',
+                            updated_at: '2019-10-03T11:54:10.123Z',
+                        },
+                    ],
+                });
+
+            return appTester(App.creates.update_member.operation.perform, bundle).then((member) => {
+                expect(apiMock.isDone()).toBe(true);
+
+                expect(member.id).toBe('5c9c9c8d51b5bf974afad2a4');
+                expect(member.status).toBe('comped');
+            });
+        });
+
+        it('removes complimentary subscriptions with an empty tiers array', function () {
+            let bundle = Object.assign(
+                {},
+                { authData },
+                {
+                    inputData: {
+                        id: '5c9c9c8d51b5bf974afad2a4',
+                        comped_remove: true,
+                    },
+                },
+            );
+
+            apiMock
+                .put('/ghost/api/admin/members/5c9c9c8d51b5bf974afad2a4/', {
+                    members: [
+                        {
+                            tiers: [],
+                        },
+                    ],
+                })
+                .reply(200, {
+                    members: [
+                        {
+                            id: '5c9c9c8d51b5bf974afad2a4',
+                            name: 'Test Member',
+                            email: 'test@example.com',
+                            status: 'free',
+                            comped: false,
+                            labels: [],
+                            created_at: '2019-10-03T11:54:10.123Z',
+                            updated_at: '2019-10-03T11:54:10.123Z',
+                        },
+                    ],
+                });
+
+            return appTester(App.creates.update_member.operation.perform, bundle).then((member) => {
+                expect(apiMock.isDone()).toBe(true);
+
+                expect(member.id).toBe('5c9c9c8d51b5bf974afad2a4');
+                expect(member.status).toBe('free');
+            });
+        });
+
+        it('rejects combining a complimentary tier with the remove flag', function () {
+            let bundle = Object.assign(
+                {},
+                { authData },
+                {
+                    inputData: {
+                        id: '5c9c9c8d51b5bf974afad2a4',
+                        comped_tier: '6220aa04dd8021001c50e6e2',
+                        comped_remove: true,
+                    },
+                },
+            );
+
+            return appTester(App.creates.update_member.operation.perform, bundle).then(
+                () => {
+                    expect.unreachable('expected the call to be rejected');
+                },
+                (err) => {
+                    expect(err.name).toEqual('HaltedError');
+                    expect(err.message).toMatch(/not both/);
+                },
+            );
+        });
+
+        it('rejects combining the deprecated comped flag with the new complimentary fields', function () {
+            let bundle = Object.assign(
+                {},
+                { authData },
+                {
+                    inputData: {
+                        id: '5c9c9c8d51b5bf974afad2a4',
+                        // even an agreeing value is rejected - one mechanism at a time
+                        comped: false,
+                        comped_remove: true,
+                    },
+                },
+            );
+
+            return appTester(App.creates.update_member.operation.perform, bundle).then(
+                () => {
+                    expect.unreachable('expected the call to be rejected');
+                },
+                (err) => {
+                    expect(err.name).toEqual('HaltedError');
+                    expect(err.message).toMatch(/leave it blank/);
+                },
+            );
+        });
+
         it('updates a member subscribed to multiple newsletters', function () {
             let bundle = Object.assign(
                 {},

--- a/test/triggers/tier_created.test.js
+++ b/test/triggers/tier_created.test.js
@@ -1,0 +1,232 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import nock from 'nock';
+
+import zapier from 'zapier-platform-core';
+
+// Use this to make test calls into your app:
+import App from '../../index';
+const appTester = zapier.createAppTester(App);
+
+const sampleTier = {
+    id: '6220aa04dd8021001c50e6e2',
+    name: 'Premium',
+    description: null,
+    slug: 'premium',
+    active: true,
+    type: 'paid',
+    welcome_page_url: null,
+    created_at: '2022-03-03T11:16:52.000Z',
+    updated_at: '2022-03-03T11:16:52.000Z',
+    visibility: 'public',
+    benefits: [],
+    currency: 'USD',
+    monthly_price: 500,
+    yearly_price: 5000,
+    trial_days: 0,
+};
+
+describe('Triggers', function () {
+    describe('Tier Created', function () {
+        let apiMock, authData;
+
+        beforeEach(function () {
+            // the grafted tiers resource sends `Zapier/x.y.z` on its own,
+            // SDK-backed requests append ` GhostAdminSDK/x.y.z` - match both
+            apiMock = nock('http://zapier-test.ghost.io', {
+                reqheaders: {
+                    'User-Agent': new RegExp(`Zapier/${App.version}`),
+                },
+            });
+            authData = {
+                adminApiUrl: 'http://zapier-test.ghost.io',
+                adminApiKey:
+                    '5c3e1182e79eace7f58c9c3b:7202e874ccae6f1ee6688bb700f356b672fb078d8465860852652037f7c7459ddbd2f2a6e9aa05a40b499ae20027d9f9ba2e5004aa9ab6510b90a5dac674cbc1',
+            };
+        });
+
+        afterEach(function () {
+            nock.cleanAll();
+        });
+
+        it('loads tier from webhook data', function () {
+            let bundle = Object.assign(
+                {},
+                { authData },
+                {
+                    inputData: {},
+                    cleanedRequest: {
+                        tier: {
+                            current: sampleTier,
+                            previous: {},
+                        },
+                    },
+                },
+            );
+
+            return appTester(App.triggers.tier_created.operation.perform, bundle).then(([tier]) => {
+                expect(tier.id).toEqual('6220aa04dd8021001c50e6e2');
+                expect(tier.name).toEqual('Premium');
+                expect(tier.slug).toEqual('premium');
+            });
+        });
+
+        it('loads the latest active paid tier from list', function () {
+            let bundle = Object.assign(
+                {},
+                { authData },
+                {
+                    inputData: {},
+                    meta: {
+                        frontend: true,
+                    },
+                },
+            );
+
+            apiMock
+                .get('/ghost/api/admin/tiers/')
+                .query({
+                    filter: 'type:paid+active:true',
+                    order: 'created_at DESC',
+                    limit: 1,
+                })
+                .reply(200, {
+                    tiers: [sampleTier],
+                    meta: {
+                        pagination: {
+                            page: 1,
+                            limit: 1,
+                            pages: 1,
+                            total: 1,
+                            next: null,
+                            prev: null,
+                        },
+                    },
+                });
+
+            return appTester(App.triggers.tier_created.operation.performList, bundle).then(
+                (results) => {
+                    expect(apiMock.isDone()).toBe(true);
+                    expect(results.length).toEqual(1);
+
+                    let [firstTier] = results;
+                    expect(firstTier.id).toEqual('6220aa04dd8021001c50e6e2');
+                    expect(firstTier.name).toEqual('Premium');
+                    expect(firstTier.type).toEqual('paid');
+                },
+            );
+        });
+
+        it('loads all active paid tiers when filling dynamic dropdown', function () {
+            let bundle = Object.assign(
+                {},
+                { authData },
+                {
+                    inputData: {},
+                    meta: {
+                        isFillingDynamicDropdown: true,
+                    },
+                },
+            );
+
+            apiMock
+                .get('/ghost/api/admin/tiers/')
+                .query({
+                    filter: 'type:paid+active:true',
+                    order: 'name DESC',
+                    limit: 'all',
+                })
+                .reply(200, {
+                    tiers: [
+                        sampleTier,
+                        {
+                            ...sampleTier,
+                            id: '6220aa04dd8021001c50e6e3',
+                            name: 'Gold',
+                            slug: 'gold',
+                            monthly_price: 1000,
+                            yearly_price: 10000,
+                        },
+                    ],
+                    meta: {
+                        pagination: {
+                            page: 1,
+                            limit: 'all',
+                            pages: 1,
+                            total: 2,
+                            next: null,
+                            prev: null,
+                        },
+                    },
+                });
+
+            return appTester(App.triggers.tier_created.operation.performList, bundle).then(
+                (results) => {
+                    expect(apiMock.isDone()).toBe(true);
+                    expect(results.length).toEqual(2);
+
+                    let [firstTier, secondTier] = results;
+                    expect(firstTier.name).toEqual('Premium');
+                    expect(secondTier.name).toEqual('Gold');
+                },
+            );
+        });
+
+        it('subscribes to webhook', function () {
+            let bundle = Object.assign(
+                {},
+                { authData },
+                {
+                    targetUrl: 'https://webooks.zapier.com/ghost/tier',
+                },
+            );
+
+            apiMock
+                .post('/ghost/api/admin/webhooks/', {
+                    webhooks: [
+                        {
+                            integration_id: '5c3e1182e79eace7f58c9c3b',
+                            target_url: 'https://webooks.zapier.com/ghost/tier',
+                            event: 'tier.added',
+                        },
+                    ],
+                })
+                .reply(201, {
+                    webhooks: [
+                        {
+                            id: '12345',
+                            target_url: 'https://webooks.zapier.com/ghost/tier',
+                            event: 'tier.added',
+                        },
+                    ],
+                });
+
+            return appTester(App.triggers.tier_created.operation.performSubscribe, bundle).then(
+                () => {
+                    expect(apiMock.isDone()).toBe(true);
+                },
+            );
+        });
+
+        it('unsubscribes from webhook', function () {
+            let bundle = Object.assign(
+                {},
+                { authData },
+                {
+                    subscribeData: {
+                        id: '12345',
+                        target_url: 'https://webooks.zapier.com/ghost/tier',
+                        event: 'tier.added',
+                    },
+                },
+            );
+
+            apiMock.delete('/ghost/api/admin/webhooks/12345/').reply(204);
+
+            return appTester(App.triggers.tier_created.operation.performUnsubscribe, bundle).then(
+                () => {
+                    expect(apiMock.isDone()).toBe(true);
+                },
+            );
+        });
+    });
+});


### PR DESCRIPTION
Lets Zapier users comp a member into a **specific tier** and **remove complimentary subscriptions**, instead of only the legacy `comped` boolean (which comps into the default tier via a deprecated Ghost code path kept alive for this integration).

Closes #64
ref [GVA-831](https://linear.app/ghost/issue/GVA-831/clean-repos-zapier)

## What changed

- **New hidden `tier_created` trigger** feeding dynamic tier dropdowns, mirroring how `newsletter_created` feeds the newsletter dropdowns (hidden, hook-typed, `performList` does the real work). `@tryghost/admin-api` 1.14.10 has no tiers resource, so `initAdminApi` grafts a browse-only one onto the SDK instance, reusing the SDK's own token signer (`@tryghost/admin-api/lib/token`) and the app's `makeRequest`, keeping auth, error handling and the `User-Agent` prefix identical to every other resource. If a future SDK bump moves that file, every test fails at require time, so it can't break silently. The list is filtered to `type:paid+active:true` — the same set Ghost Admin's own "Make complimentary" UI offers.
- **Create Member**: new optional "Complimentary tier" dynamic dropdown → sends `tiers: [{id}]` (Ghost's input serializer maps `tiers` to `products`; the same payload Ghost Admin sends).
- **Update Member**: the same "Complimentary tier" dropdown, plus a "Remove complimentary subscriptions" boolean → sends `tiers: []`, which removes all complimentary subscriptions.
- **`comped` keeps working unchanged** for existing Zaps; its helpText now spells out the default-tier behavior, the Stripe requirement, and the replacement fields.

## Precedence rules

The complimentary inputs are mutually exclusive — contradictory input **halts with a clear message** instead of being resolved by guesswork:

| Input | Result |
| --- | --- |
| `Complimentary tier` alone | `tiers: [{id}]` |
| `Remove complimentary subscriptions` alone (update only) | `tiers: []` |
| `comped` alone | legacy `comped` boolean, unchanged |
| tier **and** remove | HaltedError |
| tier or remove **combined with** `comped` | HaltedError — on update even an "agreeing" `comped: false` + remove is rejected, because `false` actively removes a comp via the deprecated path; the rule stays simple: one mechanism at a time (on create, only a truthy `comped` counts as used, since `comped: false` is a no-op there) |

## Real no-Stripe behavior (verified empirically, asserted in e2e)

Probed against a fresh `ghost:6` (v6.49) container with no Stripe connected, and cross-checked against Ghost's `member-repository.js` / `member-bread-service.js`:

- A fresh install ships **one active paid tier** (named after the site, slug `default-product`) even without Stripe, so the dropdown has something to offer out of the box.
- **Create with `tiers: [{id}]` fully comps the member without Stripe**: status becomes `comped` and a Complimentary subscription is serialized.
- **Edit with `tiers` is only half-applied without Stripe**: Ghost's member repository gates its status recalculation on Stripe being configured (`needsProducts = stripeAPIService.configured && data.products`), so tiers attach/detach but `status` stays as it was (`free` stays `free` after attaching; `comped` stays `comped` after removal). On a Stripe-connected site the same request recalculates the status — this is a Ghost quirk the integration cannot paper over, and the e2e asserts the real behavior rather than faking success.
- **The deprecated `comped: true` is rejected outright on create without Stripe** (422 `Missing Stripe connection`, surfaced as a HaltedError) and **silently ignored on edit** (Ghost wraps the whole comped edit path in `if (stripeService.configured)`).
- Ghost accepts a `tier.added` webhook subscription (it never fires — Ghost's webhook event list has no tier events — exactly like the existing `newsletter_created` trigger, whose `newsletter.added` also never fires; for hidden dropdown triggers only `performList` matters).

## Review follow-ups

- The Stripe-gated update caveat is now also in the two update-side helpTexts users see in the Zap editor (9b4c799).
- The new comp booleans are guarded against Zapier's occasionally-stringified boolean inputs via `isEnabled()` — only `true`/`'true'` count, so a `'false'` string can neither clear comps nor trip the mutual-exclusion error (12898b1). Legacy `comped`/`subscribed`/`send_email` handling is deliberately untouched.

## Tests

- Unit: 96 → **112 passed**, coverage stays **100%** across all four gates (statements/branches/functions/lines).
- E2E (fresh `ghost:6` container): 29 → **35 passed** — tier dropdown browse, comp on create, the removal and attach-on-update quirks above, legacy `comped` rejection, and the `tier_created` webhook subscribe/unsubscribe round-trip.

## `zapier validate`

```
- Running integration checks
    - 25 checks passed
    - 0 checks failed
    - 0 checks with publishing warning
    - 14 checks with general warning
```

The 14 warnings are the pre-existing D028/D002/D026 advisories on the existing operations; none relate to the new trigger or fields. The change is schema-additive (new hidden trigger + optional fields), so existing Zaps are unaffected.

