### PR TITLE
Prepare the changelog for the next major release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,37 @@
+## Unreleased (next major)
+
+Breaking changes:
+
+* (Breaking) Requires Ghost 6.0 or later to connect. Zaps created on earlier
+  integration versions keep working against older Ghost sites; maintenance
+  releases for those users ship from the `2.x` branch.
+* (Breaking) Removed the deprecated "subscriber" triggers, search, and actions
+  (Create/Delete Subscriber, Subscriber Created/Deleted). The underlying API
+  was removed in Ghost 3.0 — these operations were hidden and only ever
+  returned an error.
+* (Breaking) The integration now runs on Zapier's Node 22 runtime via
+  zapier-platform-core 19 (previously Node 14 / core 12).
+* (Breaking) All requests target the unversioned Admin API
+  (`/ghost/api/admin/`) with an `Accept-Version: v6.0` header instead of the
+  legacy `/v2/`/`/v3/` paths.
+
+New:
+
+* (New) Comp members into a specific tier: "Complimentary tier" dropdown on
+  Create Member and Update Member (sends `tiers`), plus a "Remove
+  complimentary subscription" option on Update Member. The legacy
+  "Complimentary premium plan" boolean keeps working (default tier only).
+* (New) Clearer Member field help on Update Member and realistic Ghost 6
+  sample data (including `status` and `newsletters`) for member operations.
+
+Fixes:
+
+* (Fix) Tag Created trigger read the wrong webhook payload key and returned
+  no tag data when fired.
+* (Fix) Member and Author searches detect "not found" by response status
+  instead of error-message text, so empty search results are returned
+  reliably on current Ghost versions.
+
 ## 2.6.3
 
 * Add `uuid` to Member Updated trigger


### PR DESCRIPTION
Adds an **Unreleased (next major)** section to CHANGELOG.md collecting everything user-visible since 2.6.3, in the file's existing `(New)/(Fix)` style plus a `(Breaking)` prefix for the majors. At deploy time: rename the heading to the chosen version (e.g. `## 3.0.0`) — nothing else to edit.

Notes:
- The **complimentary tier** entry assumes #121 lands before the release — drop that bullet if it doesn't.
- A condensed blurb for `zapier-platform promote`'s changelog prompt, if you want one:
  > Requires Ghost 6.0+. Comp members into a specific tier (or remove comps) on Create/Update Member. Removes the long-dead subscriber operations. Fixes the Tag Created trigger payload and empty search results on current Ghost versions.
- Versioning itself stays owner-managed (no package.json change here).

ref [GVA-831](https://linear.app/ghost/issue/GVA-831/clean-repos-zapier)