### PR TITLE
Add Zapier integration and testing docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,8 +2,9 @@
 
 Ghost's official Zapier integration — a Zapier Platform CLI app
 (`zapier-platform-core` 19, Node 22, CommonJS). See [README.md](README.md)
-for what it does and [docs/deployment.md](docs/deployment.md) for the release
-runbook.
+for the overview, [docs/integration.md](docs/integration.md) for the app
+surface, [docs/testing.md](docs/testing.md) for testing, and
+[docs/deployment.md](docs/deployment.md) for the release runbook.
 
 ## Commands
 
@@ -31,6 +32,10 @@ via `node test-e2e/setup/bootstrap.js` (set `GHOST_URL` if it is not on
   run `pnpm ship` / `pro-ship` (it pushes straight to main via a ruleset
   bypass and *is* the deploy trigger), and never create releases or tags —
   releasing is human-owned.
+- **Zapier platform CLI/browser access uses the owner account.** For
+  `zapier-platform login`, `validate`, `versions`, or fallback runbooks, use
+  the `info+zapier@ghost.org` Zapier account from 1Password; don't use a
+  personal Zapier account.
 - **Never bump `version` in package.json.** `pnpm ship` owns the version:
   it bumps, commits, and tags in one step. The publish workflow finalizes
   `CHANGELOG.md`'s `## Unreleased` heading, which the release requires —
@@ -68,3 +73,8 @@ via `node test-e2e/setup/bootstrap.js` (set `GHOST_URL` if it is not on
 - The `sample` objects in `app/` triggers/creates/searches mirror real
   Ghost 6 API shapes and are shown to users in the Zap editor — don't trim
   or invent fields.
+- For complimentary-member work, read
+  [docs/integration.md](docs/integration.md#complimentary-members) first:
+  the old `comped` field is deprecated but must keep working for existing
+  Zaps, while the newer tier-specific fields must stay mutually exclusive
+  with it.

--- a/README.md
+++ b/README.md
@@ -10,13 +10,16 @@ Zapier users connect their Ghost site with an Admin API key and URL (from
 Ghost Admin under `Integrations » Zapier`) and build Zaps from:
 
 - **Triggers** — instant REST hooks fed by Ghost webhooks: post/page
-  published, post scheduled, member created/updated/deleted, tag, author,
-  newsletter, and tier created
+  published, post scheduled, and member created/updated/deleted
 - **Creates** — create a post, create or update a member
 - **Searches** — find a member or an author
 
 All requests target the unversioned Admin API (`/ghost/api/admin/`) and
 declare their compatibility version via the `Accept-Version` header.
+
+For the full trigger/action inventory, including hidden dropdown providers
+for authors, tags, newsletters, and tiers, see
+[docs/integration.md](docs/integration.md).
 
 ## How it works
 
@@ -92,6 +95,9 @@ suite, and tears everything down again. Alternatives:
 - run any **fresh** Ghost install yourself, then
   `node test-e2e/setup/bootstrap.js` (set `GHOST_URL` if it is not on
   `http://localhost:2368`) followed by `pnpm test:e2e`
+
+More detail, including testing a private Zapier version against a local Ghost,
+lives in [docs/testing.md](docs/testing.md).
 
 ## Deployment
 

--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ for details.
 # `pnpm exec zapier-platform`; the binary is called `zapier-platform` since v19)
 pnpm install
 
-# authenticate against Zapier's platform with a deploy key (only needed for
-# platform commands like `versions` - deploys themselves run from CI)
+# authenticate against Zapier's platform for CLI commands. Use the
+# `info+zapier@ghost.org` Zapier account from 1Password.
 pnpm exec zapier-platform login
 ```
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -20,9 +20,10 @@ bookkeeping commit, which is pushed by the Actions bot and therefore
 triggers no Test run and no preview (its content shipped as the release
 anyway).
 
-To try the current main: open the Zap editor with the developer account and
-pick version `0.0.0-preview` of the Ghost integration. To test against a
-local Ghost, use the private-version flow in
+To try the current main: sign in to the Zapier developer account from
+1Password (`info+zapier@ghost.org`), open the Zap editor, and pick version
+`0.0.0-preview` of the Ghost integration. To test against a local Ghost, use
+the private-version flow in
 [testing.md](testing.md#testing-a-private-zapier-version-against-local-ghost).
 
 ## Releasing: `pnpm ship`
@@ -63,8 +64,9 @@ local Ghost, use the private-version flow in
      so the changelog history lands on main without anyone pushing to it
      directly.
 4. **Migrate existing users — the only manual step.** Roll out gradually and
-   watch [Zapier's error dashboard](https://developer.zapier.com/) between
-   steps:
+   watch the [Zapier developer dashboard for app 1566](https://developer.zapier.com/app/1566)
+   between steps. Use the `info+zapier@ghost.org` Zapier account from
+   1Password:
 
    ```sh
    zapier-platform migrate 2.6.3 3.0.0 10   # then 50, then 100
@@ -97,9 +99,10 @@ One-time setup before the workflows can deploy, plus a supervised first
 release:
 
 1. **Create a deploy key**: sign in to the
-   [Zapier developer platform](https://developer.zapier.com/) with the
-   integration's owner account and generate a deploy key for app 1566
-   (the same credential `zapier-platform login` provisions).
+   [Zapier developer dashboard](https://developer.zapier.com/app/1566) with
+   the integration's owner account from 1Password (`info+zapier@ghost.org`)
+   and generate a deploy key for app 1566 (the same credential
+   `zapier-platform login` provisions).
 2. **Create the `zapier` GitHub environment** (repo Settings → Environments)
    and add the key as the `ZAPIER_DEPLOY_KEY` environment secret. Both
    workflows request this environment; until it exists with the secret,
@@ -182,6 +185,8 @@ To check changes against a production-like setup before promoting:
 1. In your regular Zapier account, create a new Zap and select the Ghost
    version under test (`0.0.0-preview`, or migrate a single user account's
    Zaps to it: `zapier-platform migrate 2.6.3 2.6.4 --user=user@example.com`).
+   If you need the owner/developer account, use the `info+zapier@ghost.org`
+   credentials from 1Password.
 2. Expose your local Ghost instance so Zapier can reach it — we use
    [Tailscale Funnel](https://tailscale.com/kb/1223/funnel):
    `tailscale funnel 2368`. (Any tunnel that gives you a public HTTPS URL
@@ -189,8 +194,8 @@ To check changes against a production-like setup before promoting:
 3. Connect the Zap to your local instance via the public URL the tunnel
    printed.
 4. Use your local Ghost as usual — webhook deliveries and API requests from
-   Zapier now hit it. If nothing comes through, check Zapier's error
-   dashboard.
+   Zapier now hit it. If nothing comes through, check the
+   [Zapier developer dashboard for app 1566](https://developer.zapier.com/app/1566).
 
 ## Maintenance releases for the previous major
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -102,7 +102,9 @@ release:
    [Zapier developer dashboard](https://developer.zapier.com/app/1566) with
    the integration's owner account from 1Password (`info+zapier@ghost.org`)
    and generate a deploy key for app 1566 (the same credential
-   `zapier-platform login` provisions).
+   `zapier-platform login` provisions). Use that same 1Password account when
+   the Zapier Platform CLI login flow asks you to authenticate in the
+   browser.
 2. **Create the `zapier` GitHub environment** (repo Settings → Environments)
    and add the key as the `ZAPIER_DEPLOY_KEY` environment secret. Both
    workflows request this environment; until it exists with the secret,
@@ -216,7 +218,8 @@ follow the [fallback runbook](#fallback-manual-cli-runbook).
 
 For 2.x maintenance releases, or if the workflows are unavailable. You need
 the CLI (`npm install --global zapier-platform-cli` — the binary is called
-`zapier-platform` since v19) and `zapier-platform login`.
+`zapier-platform` since v19) and `zapier-platform login`. Use the
+`info+zapier@ghost.org` Zapier account from 1Password for the CLI login flow.
 
 1. Set the version in `package.json` and finalize `CHANGELOG.md` (for a
    main release: `node scripts/release-changelog.js finalize X.Y.Z`) — the

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -22,7 +22,8 @@ anyway).
 
 To try the current main: open the Zap editor with the developer account and
 pick version `0.0.0-preview` of the Ghost integration. To test against a
-local Ghost, see [below](#testing-a-private-version-against-a-local-ghost).
+local Ghost, use the private-version flow in
+[testing.md](testing.md#testing-a-private-zapier-version-against-local-ghost).
 
 ## Releasing: `pnpm ship`
 
@@ -171,6 +172,10 @@ Three smaller caveats, no action needed:
   run re-run from the Actions UI; nothing has half-happened.
 
 ## Testing a private version against a local Ghost
+
+The fuller testing guide lives in
+[testing.md](testing.md#testing-a-private-zapier-version-against-local-ghost).
+The short version:
 
 To check changes against a production-like setup before promoting:
 

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -116,6 +116,26 @@ newer complimentary tier fields are mutually exclusive with the deprecated
 default-tier field, and the code halts the Zap instead of guessing when a user
 sets conflicting inputs.
 
+## Complimentary members
+
+The current member actions let Zap users manage complimentary access more
+precisely than the old `comped` boolean allowed. Create Member and Update
+Member both expose `Complimentary tier`, which assigns the member to a
+specific active paid tier. Update Member also exposes `Remove complimentary
+subscriptions`, which sends an empty `tiers` array to Ghost and removes the
+member's complimentary tier assignments.
+
+The older `Complimentary premium plan` field still exists for existing Zaps,
+but it is deprecated. It can only add or remove the site's default
+complimentary tier and it still depends on the legacy Ghost `comped` behavior.
+Do not combine it with the newer tier-specific fields; the app returns a
+halted error instead of guessing which complimentary path should win.
+
+One Ghost edge case is deliberate: on sites without Stripe connected, Ghost
+can attach or detach tiers but may not immediately recalculate the member's
+status. The Zapier field help text calls that out because the API result can
+look surprising even though the tier assignment changed.
+
 Searches live in `app/searches/`. Member search filters by email. Author
 search reads by either email address or slug.
 

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -1,0 +1,138 @@
+# Integration map
+
+This repo is the code for Ghost's public Zapier integration. It is a Zapier
+Platform CLI app: Zapier runs the app, users connect a Ghost site, and the app
+talks to that site through the Ghost Admin API and Ghost webhooks.
+
+The current app supports Ghost 6 and later. The compatibility floor and the
+Admin API `Accept-Version` header live together in `app/lib/utils.js`.
+
+## User-facing surface
+
+Triggers are instant REST hooks. When a user turns on a Zap, Zapier calls the
+trigger's subscribe function, this app creates a webhook in Ghost, and Ghost
+sends matching events back to Zapier.
+
+Public triggers:
+
+- Member Created
+- Member Deleted
+- Member Updated
+- Page Published
+- Post Published
+- Post Scheduled
+
+Hidden triggers used as dynamic dropdown providers:
+
+- Author Created
+- Newsletter Created
+- Tag Created
+- Tier Created
+
+Creates call the Admin API directly:
+
+- Create Member
+- Update Member
+- Create Post
+
+Searches call the Admin API directly and return an empty result on a Ghost 404:
+
+- Find an Author, by email address or slug
+- Find a Member, by email address
+
+Subscriber actions and searches are gone from the current app. Older Zapier
+integration versions may still have them, but new work should use the member
+surface.
+
+## How requests flow
+
+```mermaid
+sequenceDiagram
+    participant User as Zapier user
+    participant Zapier as Zapier platform
+    participant App as Ghost Zapier app
+    participant Ghost as Ghost Admin API
+
+    User->>Zapier: Connects a Ghost site
+    Zapier->>App: Run auth test with URL and Admin API key
+    App->>Ghost: Read site and config
+    Ghost-->>App: Site version, title, URL
+    App-->>Zapier: Connection label data
+
+    User->>Zapier: Enables an instant trigger
+    Zapier->>App: Subscribe with target URL
+    App->>Ghost: Create webhook for the Ghost event
+    Ghost-->>App: Webhook id
+    App-->>Zapier: Store subscribe data
+
+    Ghost->>Zapier: Send webhook payload
+    Zapier->>App: Run trigger perform
+    App-->>Zapier: Normalized trigger result
+
+    User->>Zapier: Runs a create or search step
+    Zapier->>App: Run action/search perform
+    App->>Ghost: Admin API request
+    Ghost-->>App: Resource data
+    App-->>Zapier: Zap step output
+```
+
+## Code paths
+
+`app/index.js` wires the Zapier app together. It imports authentication,
+triggers, creates, and searches, then exposes the installed package version
+and `zapier-platform-core` version for upload.
+
+`app/authentication.js` validates new connections. It reads the site endpoint,
+checks the Ghost version against `SUPPORTED_GHOST_VERSION`, then reads config
+with the supplied Admin API key so a site that exposes public config cannot
+pass auth with a bad key. The connection label uses the Ghost site URL, not a
+secret.
+
+`app/lib/utils.js` builds the Admin API client. It adds this app's user agent,
+uses the unversioned Admin API with the Ghost 6 `Accept-Version` header, maps
+Ghost validation and not-found errors to Zapier halted errors, and grafts a
+browse-only `tiers` resource onto `@tryghost/admin-api` because version
+`1.14.10` does not expose tiers.
+
+`app/lib/webhooks.js` owns webhook subscription and unsubscription. It derives
+the Ghost integration id from the Admin API key, then creates or deletes the
+webhook through the Admin API.
+
+Each trigger lives in `app/triggers/`. Public triggers and hidden dropdown
+providers share the same REST-hook shape. Most use a real `performList` call
+so Zapier can test the step or fill a dropdown without waiting for a fresh
+webhook. `member_updated` is the exception: it returns a static sample payload
+because Ghost's `member.edited` webhook includes a `current` object and a
+partial `previous` object, and there is no useful equivalent API read that can
+produce the same shape.
+
+The hidden `author_created`, `tag_created`, `newsletter_created`, and
+`tier_created` triggers provide dynamic dropdown data. `tier_created` lists
+active paid tiers through the grafted tiers resource.
+
+Creates live in `app/creates/`. Member create/update both handle single-site
+and multi-newsletter sites, labels, and complimentary subscriptions. The
+newer complimentary tier fields are mutually exclusive with the deprecated
+default-tier field, and the code halts the Zap instead of guessing when a user
+sets conflicting inputs.
+
+Searches live in `app/searches/`. Member search filters by email. Author
+search reads by either email address or slug.
+
+## Product notes
+
+The member triggers are the easiest place to surprise users. `Member Created`
+fires for the Ghost `member.added` event. `Member Updated` fires for
+`member.edited`, which can happen several times during a paid signup or a
+subscription change. That behavior is accurate to Ghost's webhook model, but
+it can make a Zap run more often than a user expects.
+
+The sample objects in `app/` are part of the Zap editor experience. Keep them
+close to real Ghost 6 API shapes, especially for webhook triggers where Zapier
+uses sample and polling data during setup.
+
+There is still room to add more Ghost resources. The current app has no public
+search or create surface for tiers, newsletters, offers, recommendations, or
+similar membership objects. If a feature needs one, add it deliberately with
+e2e coverage against a real Ghost rather than treating a hidden
+dynamic-dropdown provider as a public search.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -95,7 +95,8 @@ hook triggers, or connection labels. The checks look for compatibility and
 definition problems such as removed public surfaces, sample data drift,
 missing polling URLs for REST hooks, unsafe auth labels, and bad help text.
 
-Run them through the CLI when you have a deploy key available:
+Run them through the CLI when you are logged in with the Zapier owner account
+from 1Password (`info+zapier@ghost.org`):
 
 ```sh
 pnpm exec zapier-platform validate

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -71,15 +71,17 @@ private push, before promotion.
    ```
 
 3. In a regular Zapier account, create a new Zap and choose the Ghost version
-   under test.
+   under test. If you need the integration owner account, use the
+   `info+zapier@ghost.org` credentials from 1Password.
 4. Connect the Zap to the tunnel URL.
 5. Use local Ghost normally. Trigger events and Admin API calls from Zapier
    should now arrive at your local process.
 
-If nothing arrives, check the Zap run history and Zapier's developer error
-dashboard first, then check the local Ghost logs. Most failures at this layer
-are URL, auth, webhook delivery, or sample-shape problems rather than unit
-test problems.
+If nothing arrives, check the Zap run history and the
+[Zapier developer dashboard for app 1566](https://developer.zapier.com/app/1566)
+first, then check the local Ghost logs. Most failures at this layer are URL,
+auth, webhook delivery, or sample-shape problems rather than unit test
+problems.
 
 Do not run `zapier-platform push`, `promote`, or `migrate` by hand for normal
 main releases. The deploy path is in [deployment.md](deployment.md); staged

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,104 @@
+# Testing
+
+Use the local commands first, then use a private Zapier version when the
+change needs the real Zap editor or Zapier-hosted webhooks.
+
+## Local checks
+
+```sh
+pnpm lint
+pnpm test
+pnpm test:e2e
+```
+
+`pnpm test` runs the Vitest unit suite with 100% coverage thresholds. Do not
+lower those thresholds to land a change; add the missing test instead.
+
+`pnpm test:e2e` runs the Zapier app against a real Ghost. With Docker running,
+it boots a fresh `ghost:6` container, creates the owner user, creates a custom
+integration, writes the Admin API credentials to `test-e2e/.env.local`, runs
+the ordered e2e files, and tears the container down.
+
+The e2e files share state. They run one file at a time in filename order, and
+`02-creates.test.js` seeds fixtures the later trigger and search tests assert
+on. Do not parallelize the e2e config or renumber those files.
+
+## Testing against Ghost source
+
+To test against a Ghost checkout instead of the Docker image:
+
+```sh
+cd /path/to/Ghost
+pnpm install --frozen-lockfile --filter ghost...
+
+cd /path/to/Zapier
+GHOST_CORE_PATH=/path/to/Ghost pnpm test:e2e
+```
+
+The runner starts Ghost from that checkout, bootstraps it through HTTP, runs
+the e2e suite, and stops the process on exit.
+
+## Testing against a Ghost you started yourself
+
+Use a fresh Ghost. The e2e fixtures use fixed emails, titles, slugs, and other
+values, so a reused seeded site will usually fail for the right reason.
+
+```sh
+GHOST_URL=http://localhost:2368 node test-e2e/setup/bootstrap.js
+pnpm test:e2e
+```
+
+`GHOST_URL` defaults to `http://localhost:2368`. The bootstrap script only
+supports local `http://` URLs because it uses Node's `http` module directly.
+
+If `GHOST_ADMIN_API_URL` and `GHOST_ADMIN_API_KEY` are already exported,
+`pnpm test:e2e` skips provisioning and runs the bare Vitest e2e suite.
+
+## Testing a private Zapier version against local Ghost
+
+Use this when you need to see Zapier-hosted behavior in the real Zap editor.
+The normal candidate is `0.0.0-preview`, which GitHub Actions refreshes after
+every green Test run on main. Release candidates can also be tested after a
+private push, before promotion.
+
+1. Start Ghost locally.
+2. Expose it through a public HTTPS tunnel:
+
+   ```sh
+   tailscale funnel 2368
+   # or:
+   ngrok http http://localhost:2368
+   ```
+
+3. In a regular Zapier account, create a new Zap and choose the Ghost version
+   under test.
+4. Connect the Zap to the tunnel URL.
+5. Use local Ghost normally. Trigger events and Admin API calls from Zapier
+   should now arrive at your local process.
+
+If nothing arrives, check the Zap run history and Zapier's developer error
+dashboard first, then check the local Ghost logs. Most failures at this layer
+are URL, auth, webhook delivery, or sample-shape problems rather than unit
+test problems.
+
+Do not run `zapier-platform push`, `promote`, or `migrate` by hand for normal
+main releases. The deploy path is in [deployment.md](deployment.md); staged
+user migration is the only manual release step.
+
+## Zapier validation checks
+
+Zapier's validation checks are worth running before a larger user-facing
+change, especially when changing input fields, samples, output fields, REST
+hook triggers, or connection labels. The checks look for compatibility and
+definition problems such as removed public surfaces, sample data drift,
+missing polling URLs for REST hooks, unsafe auth labels, and bad help text.
+
+Run them through the CLI when you have a deploy key available:
+
+```sh
+pnpm exec zapier-platform validate
+```
+
+Warnings are not always blockers for private versions, but do read them. A
+warning about samples, polling data, or field compatibility is usually a real
+Zap editor or migration problem waiting to happen.


### PR DESCRIPTION
## Summary
- add a repo-owned integration map for the upgraded Zapier app
- document local, real-Ghost, and private-preview testing flows
- link the README and deployment docs to the new supporting docs

## Testing
- pnpm lint
- pnpm test